### PR TITLE
fix: 認証フォームのローディング状態とDBトリガーを修正

### DIFF
--- a/app/(auth)/login.tsx
+++ b/app/(auth)/login.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useSession, useSessionApi } from '@/state/session';
+import { useSessionApi } from '@/state/session';
 
 /**
  * ログイン画面
@@ -19,12 +19,12 @@ import { useSession, useSessionApi } from '@/state/session';
  */
 export default function LoginScreen() {
   const router = useRouter();
-  const { isLoading } = useSession();
   const { signInWithEmail } = useSessionApi();
 
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleLogin = async () => {
     setError(null);
@@ -39,6 +39,7 @@ export default function LoginScreen() {
       return;
     }
 
+    setIsSubmitting(true);
     try {
       await signInWithEmail(email.trim(), password);
       // 成功時は onAuthStateChange でリダイレクトされる
@@ -49,6 +50,8 @@ export default function LoginScreen() {
       } else {
         setError('ログインに失敗しました。もう一度お試しください');
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -96,7 +99,7 @@ export default function LoginScreen() {
                 autoCapitalize="none"
                 autoComplete="email"
                 autoCorrect={false}
-                editable={!isLoading}
+                editable={!isSubmitting}
               />
             </View>
 
@@ -112,7 +115,7 @@ export default function LoginScreen() {
                 secureTextEntry
                 autoCapitalize="none"
                 autoComplete="password"
-                editable={!isLoading}
+                editable={!isSubmitting}
               />
             </View>
 
@@ -120,12 +123,12 @@ export default function LoginScreen() {
             <Pressable
               style={[
                 styles.loginButton,
-                isLoading && styles.loginButtonDisabled,
+                isSubmitting && styles.loginButtonDisabled,
               ]}
               onPress={handleLogin}
-              disabled={isLoading}
+              disabled={isSubmitting}
             >
-              {isLoading ? (
+              {isSubmitting ? (
                 <ActivityIndicator color="#fff" />
               ) : (
                 <Text style={styles.loginButtonText}>サインイン</Text>

--- a/app/(auth)/signup.tsx
+++ b/app/(auth)/signup.tsx
@@ -12,7 +12,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { useSession, useSessionApi } from '@/state/session';
+import { useSessionApi } from '@/state/session';
 
 /**
  * サインアップ画面
@@ -20,7 +20,6 @@ import { useSession, useSessionApi } from '@/state/session';
  */
 export default function SignupScreen() {
   const router = useRouter();
-  const { isLoading } = useSession();
   const { signUpWithEmail } = useSessionApi();
 
   const [email, setEmail] = useState('');
@@ -28,6 +27,7 @@ export default function SignupScreen() {
   const [confirmPassword, setConfirmPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
   const [success, setSuccess] = useState(false);
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSignup = async () => {
     setError(null);
@@ -50,6 +50,7 @@ export default function SignupScreen() {
       return;
     }
 
+    setIsSubmitting(true);
     try {
       await signUpWithEmail(email.trim(), password);
       setSuccess(true);
@@ -60,6 +61,8 @@ export default function SignupScreen() {
       } else {
         setError('登録に失敗しました。もう一度お試しください');
       }
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
@@ -135,7 +138,7 @@ export default function SignupScreen() {
                   autoCapitalize="none"
                   autoComplete="email"
                   autoCorrect={false}
-                  editable={!isLoading}
+                  editable={!isSubmitting}
                 />
               </View>
 
@@ -151,7 +154,7 @@ export default function SignupScreen() {
                   secureTextEntry
                   autoCapitalize="none"
                   autoComplete="new-password"
-                  editable={!isLoading}
+                  editable={!isSubmitting}
                 />
               </View>
 
@@ -167,7 +170,7 @@ export default function SignupScreen() {
                   secureTextEntry
                   autoCapitalize="none"
                   autoComplete="new-password"
-                  editable={!isLoading}
+                  editable={!isSubmitting}
                 />
               </View>
 
@@ -175,12 +178,12 @@ export default function SignupScreen() {
               <Pressable
                 style={[
                   styles.signupButton,
-                  isLoading && styles.signupButtonDisabled,
+                  isSubmitting && styles.signupButtonDisabled,
                 ]}
                 onPress={handleSignup}
-                disabled={isLoading}
+                disabled={isSubmitting}
               >
-                {isLoading ? (
+                {isSubmitting ? (
                   <ActivityIndicator color="#fff" />
                 ) : (
                   <Text style={styles.signupButtonText}>アカウント作成</Text>

--- a/supabase/migrations/20240101000000_init.sql
+++ b/supabase/migrations/20240101000000_init.sql
@@ -237,15 +237,19 @@ CREATE TRIGGER user_settings_updated_at
 -- Function to create default settings for new users
 -- ===========================================
 
-CREATE OR REPLACE FUNCTION handle_new_user()
-RETURNS TRIGGER AS $$
+CREATE OR REPLACE FUNCTION public.handle_new_user()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
 BEGIN
-  INSERT INTO user_settings (user_id)
+  INSERT INTO public.user_settings (user_id)
   VALUES (NEW.id)
   ON CONFLICT (user_id) DO NOTHING;
   RETURN NEW;
 END;
-$$ LANGUAGE plpgsql SECURITY DEFINER;
+$$;
 
 -- Trigger for new user signup
 CREATE TRIGGER on_auth_user_created


### PR DESCRIPTION
- ログイン/サインアップ画面でローカルの isSubmitting 状態を使用
  - グローバルの isLoading に依存せず、初期化中でもフォーム操作が可能に
- handle_new_user() 関数に SET search_path = public を追加
  - supabase_auth_admin からの呼び出し時のスキーマ解決問題を修正