### PR TITLE
feat: Docker web frontend and deploy configuration

### DIFF
--- a/.env.deploy.example
+++ b/.env.deploy.example
@@ -1,0 +1,25 @@
+# ===========================================
+# Habity Deploy Configuration
+# Copy to .env.deploy and fill in actual values
+# ===========================================
+
+# ===========================================
+# Supabase Cloud
+# Get from: https://supabase.com/dashboard/project/<project>/settings/api
+# ===========================================
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_KEY=your-service-role-key
+JWT_SECRET=your-jwt-secret
+
+# ===========================================
+# Database (Supabase Cloud PostgreSQL)
+# Get from: https://supabase.com/dashboard/project/<project>/settings/database
+# ===========================================
+DATABASE_URL=postgresql://postgres.your-project:your-password@aws-0-ap-northeast-1.pooler.supabase.com:6543/postgres
+
+# ===========================================
+# Web Frontend
+# ===========================================
+WEB_PORT=3000
+BACKEND_URL=http://localhost:3000

--- a/.env.example
+++ b/.env.example
@@ -30,8 +30,16 @@ ENABLE_EMAIL_SIGNUP=true
 ENABLE_EMAIL_AUTOCONFIRM=true
 
 # ===========================================
-# React Native / Expo
+# React Native / Expo (for local dev with pnpm web)
 # ===========================================
 EXPO_PUBLIC_SUPABASE_URL=http://localhost:54321
 EXPO_PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0
 EXPO_PUBLIC_BACKEND_URL=http://localhost:8088
+
+# ===========================================
+# Web Frontend (Docker)
+# nginx reverse proxy port and runtime env vars
+# ===========================================
+WEB_PORT=3000
+WEB_SUPABASE_URL=http://localhost:3000
+WEB_BACKEND_URL=http://localhost:3000

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,47 @@
+# ===========================================
+# Stage 1: Build Expo Web
+# ===========================================
+FROM node:24-alpine AS builder
+
+RUN corepack enable && corepack prepare pnpm@10.28.0 --activate
+
+WORKDIR /app
+
+# Copy dependency files first for caching
+COPY package.json pnpm-lock.yaml .npmrc ./
+
+RUN pnpm install --frozen-lockfile
+
+# Copy source files
+COPY app.config.js babel.config.js metro.config.js tsconfig.json lingui.config.js ./
+COPY src/ src/
+COPY app/ app/
+COPY assets/ assets/
+
+# Build with placeholder values so they can be replaced at runtime
+ENV EXPO_PUBLIC_SUPABASE_URL=__HABITY_SUPABASE_URL__
+ENV EXPO_PUBLIC_SUPABASE_ANON_KEY=__HABITY_SUPABASE_ANON_KEY__
+ENV EXPO_PUBLIC_BACKEND_URL=__HABITY_BACKEND_URL__
+
+RUN npx expo export --platform web
+
+# ===========================================
+# Stage 2: Serve with nginx
+# ===========================================
+FROM nginx:alpine
+
+ARG NGINX_CONF=nginx/default.conf
+
+# Copy built files
+COPY --from=builder /app/dist /usr/share/nginx/html
+
+# Copy nginx config
+COPY ${NGINX_CONF} /etc/nginx/conf.d/default.conf
+
+# Copy entrypoint script
+COPY docker/web-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+
+EXPOSE 80
+
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,54 @@ pnpm ios
 pnpm android
 ```
 
+### 5. Web フロントエンド (Docker)
+
+開発環境では Web フロントエンドも Docker で配信できます。`docker compose up` に含まれる `web` サービスが nginx 経由で Expo Web ビルドを配信し、Supabase API と Go Backend へのリバースプロキシも行います。
+
+| サービス | URL | 説明 |
+|---------|-----|------|
+| Web フロントエンド | http://localhost:3000 | nginx + Expo Web ビルド |
+
+## デプロイ (EC2 等)
+
+デプロイ環境では Supabase Cloud を利用するため、Docker には Web フロントエンドと Go Backend のみを含めます。
+
+### アーキテクチャ
+
+```
+Browser -> nginx (port 3000)
+  ├── /          -> 静的ファイル (Expo Web ビルド)
+  ├── /api/v1/*  -> Go Backend (Docker 内)
+  └── /health    -> Go Backend (Docker 内)
+
+Supabase API -> 直接 Supabase Cloud (https://xxx.supabase.co)
+```
+
+### セットアップ
+
+```bash
+# 1. 環境変数ファイルを作成
+cp .env.deploy.example .env.deploy
+
+# 2. .env.deploy を編集して Supabase Cloud の情報を設定
+#    - SUPABASE_URL, SUPABASE_ANON_KEY, SUPABASE_SERVICE_KEY
+#    - DATABASE_URL (Supabase Cloud の PostgreSQL 接続文字列)
+#    - JWT_SECRET
+
+# 3. ビルド & 起動
+docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d --build
+
+# 4. 停止
+docker compose -f docker-compose.deploy.yml --env-file .env.deploy down
+```
+
+### Docker Compose ファイル構成
+
+| ファイル | 用途 | 含まれるサービス |
+|---------|------|----------------|
+| `docker-compose.yml` | ローカル開発 | Supabase 全スタック + Go Backend (+ Web は `--profile web` で起動) |
+| `docker-compose.deploy.yml` | デプロイ | Go Backend + Web のみ |
+
 ## プロジェクト構成
 
 ```
@@ -77,8 +125,14 @@ habity/
 │   └── types/              # 型定義
 ├── backend/                # Go バックエンド
 ├── supabase/               # Supabase 設定・マイグレーション
+├── nginx/                  # nginx 設定
+│   ├── default.conf        # 開発用 (Supabase プロキシあり)
+│   └── deploy.conf         # デプロイ用 (Backend プロキシのみ)
+├── docker/                 # Docker 関連スクリプト
 ├── docs/                   # 仕様ドキュメント
-└── docker-compose.yml      # 開発環境
+├── Dockerfile.web          # Web フロントエンド用 Dockerfile
+├── docker-compose.yml      # 開発環境 (全スタック)
+└── docker-compose.deploy.yml # デプロイ環境 (Web + Backend)
 ```
 
 ## ドキュメント
@@ -99,10 +153,18 @@ habity/
 # ツール管理
 mise install              # ツールインストール
 
-# Docker
+# Docker (開発: Supabase + Backend)
 docker compose up -d      # 起動
 docker compose down       # 停止
 docker compose logs -f    # ログ確認
+
+# Docker (開発: Web フロントエンドも含める場合)
+docker compose --profile web up -d
+docker compose --profile web down
+
+# Docker (デプロイ)
+docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d --build
+docker compose -f docker-compose.deploy.yml --env-file .env.deploy down
 
 # フロントエンド
 pnpm install              # 依存パッケージインストール

--- a/docker-compose.deploy.yml
+++ b/docker-compose.deploy.yml
@@ -1,0 +1,37 @@
+services:
+  # ===========================================
+  # Go Backend
+  # ===========================================
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    container_name: habity-backend
+    environment:
+      PORT: 8088
+      DATABASE_URL: ${DATABASE_URL}
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_SERVICE_KEY: ${SUPABASE_SERVICE_KEY}
+      JWT_SECRET: ${JWT_SECRET}
+    restart: unless-stopped
+
+  # ===========================================
+  # Web Frontend (Expo Web + nginx)
+  # ===========================================
+  web:
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+      args:
+        NGINX_CONF: nginx/deploy.conf
+    container_name: habity-web
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "${WEB_PORT:-3000}:80"
+    environment:
+      SUPABASE_URL: ${SUPABASE_URL}
+      SUPABASE_ANON_KEY: ${SUPABASE_ANON_KEY}
+      BACKEND_URL: ${BACKEND_URL:-http://localhost:3000}
+    restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -261,6 +261,29 @@ services:
     #   - ./backend:/app  # 開発時のホットリロード用（現在は無効）
     restart: unless-stopped
 
+  # ===========================================
+  # Web Frontend (Expo Web + nginx)
+  # ===========================================
+  web:
+    profiles:
+      - web
+    build:
+      context: .
+      dockerfile: Dockerfile.web
+    container_name: habity-web
+    depends_on:
+      kong:
+        condition: service_started
+      backend:
+        condition: service_started
+    ports:
+      - "${WEB_PORT:-3000}:80"
+    environment:
+      SUPABASE_URL: ${WEB_SUPABASE_URL:-http://localhost:${WEB_PORT:-3000}}
+      SUPABASE_ANON_KEY: ${ANON_KEY:-eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZS1kZW1vIiwicm9sZSI6ImFub24iLCJleHAiOjE5ODM4MTI5OTZ9.CRXP1A7WOeoJeXxjNni43kdQwgnWNReilDMblYTn_I0}
+      BACKEND_URL: ${WEB_BACKEND_URL:-http://localhost:${WEB_PORT:-3000}}
+    restart: unless-stopped
+
 volumes:
   habity-db-data:
   habity-storage-data:

--- a/docker/web-entrypoint.sh
+++ b/docker/web-entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+set -e
+
+# Replace placeholders in built JS files with actual environment variables
+# This allows the same image to be used across different environments
+HTML_DIR="/usr/share/nginx/html"
+
+if [ -n "$SUPABASE_URL" ]; then
+  find "$HTML_DIR" -type f \( -name "*.js" -o -name "*.html" \) \
+    -exec sed -i "s|__HABITY_SUPABASE_URL__|${SUPABASE_URL}|g" {} +
+fi
+
+if [ -n "$SUPABASE_ANON_KEY" ]; then
+  find "$HTML_DIR" -type f \( -name "*.js" -o -name "*.html" \) \
+    -exec sed -i "s|__HABITY_SUPABASE_ANON_KEY__|${SUPABASE_ANON_KEY}|g" {} +
+fi
+
+if [ -n "$BACKEND_URL" ]; then
+  find "$HTML_DIR" -type f \( -name "*.js" -o -name "*.html" \) \
+    -exec sed -i "s|__HABITY_BACKEND_URL__|${BACKEND_URL}|g" {} +
+fi
+
+echo "Environment variables injected into static files"
+
+# Start nginx
+exec nginx -g "daemon off;"

--- a/metro.config.js
+++ b/metro.config.js
@@ -1,3 +1,4 @@
+const path = require("path");
 const { getDefaultConfig } = require("expo/metro-config");
 
 const config = getDefaultConfig(__dirname);
@@ -7,5 +8,26 @@ config.resolver.unstable_enableSymlinks = true;
 
 // Watch all node_modules for pnpm
 config.watchFolders = [__dirname];
+
+// Force @supabase/* packages to use CJS entry points.
+// v2.92.0+ uses rolldown which emits import.meta.url in ESM builds,
+// and Metro does not support import.meta in non-module scripts.
+const originalResolveRequest = config.resolver.resolveRequest;
+config.resolver.resolveRequest = (context, moduleName, platform) => {
+  if (moduleName.startsWith("@supabase/")) {
+    const pkgName = moduleName.split("/").slice(0, 2).join("/");
+    try {
+      const pkgJson = require(`${pkgName}/package.json`);
+      if (pkgJson.main && pkgJson.main.endsWith(".cjs")) {
+        const cjsPath = require.resolve(`${pkgName}/${pkgJson.main}`);
+        return { type: "sourceFile", filePath: cjsPath };
+      }
+    } catch {}
+  }
+  if (originalResolveRequest) {
+    return originalResolveRequest(context, moduleName, platform);
+  }
+  return context.resolveRequest(context, moduleName, platform);
+};
 
 module.exports = config;

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -1,0 +1,74 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # gzip
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 256;
+
+    # Supabase REST API
+    location /rest/v1/ {
+        proxy_pass http://kong:8000/rest/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Supabase Auth
+    location /auth/v1/ {
+        proxy_pass http://kong:8000/auth/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Supabase Realtime (WebSocket)
+    location /realtime/v1/ {
+        proxy_pass http://kong:8000/realtime/v1/;
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_read_timeout 86400;
+    }
+
+    # Supabase Storage
+    location /storage/v1/ {
+        proxy_pass http://kong:8000/storage/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 50m;
+    }
+
+    # Go Backend API
+    location /api/v1/ {
+        proxy_pass http://backend:8088/api/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Go Backend health check
+    location /health {
+        proxy_pass http://backend:8088/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri /index.html;
+    }
+}

--- a/nginx/deploy.conf
+++ b/nginx/deploy.conf
@@ -1,0 +1,33 @@
+server {
+    listen 80;
+    server_name _;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # gzip
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript text/xml application/xml text/javascript image/svg+xml;
+    gzip_min_length 256;
+
+    # Go Backend API
+    location /api/v1/ {
+        proxy_pass http://backend:8088/api/v1/;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # Go Backend health check
+    location /health {
+        proxy_pass http://backend:8088/health;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+    }
+
+    # SPA fallback
+    location / {
+        try_files $uri /index.html;
+    }
+}


### PR DESCRIPTION
## Summary
- Expo Web ビルドを nginx で配信する `Dockerfile.web` と nginx 設定を追加
- デプロイ用 `docker-compose.deploy.yml`（web + backend のみ、Supabase Cloud 利用）を追加
- 開発用 `docker-compose.yml` の web サービスを profiles で分離し、`docker compose up` では起動しないように変更
- `@supabase/*` v2.92.0+ の `import.meta` 問題を Metro 設定で修正

## Detail

### 開発環境
```bash
# Supabase + Backend のみ（従来通り pnpm web で開発）
docker compose up -d

# Web フロントエンドも Docker で起動する場合
docker compose --profile web up -d
```

### デプロイ環境（EC2 等）
```bash
cp .env.deploy.example .env.deploy
# .env.deploy を編集
docker compose -f docker-compose.deploy.yml --env-file .env.deploy up -d --build
```

### ファイル構成
| ファイル | 内容 |
|---------|------|
| `Dockerfile.web` | Expo Web ビルド + nginx (NGINX_CONF ビルド引数対応) |
| `nginx/default.conf` | 開発用 (Supabase + Backend プロキシ) |
| `nginx/deploy.conf` | デプロイ用 (Backend プロキシのみ) |
| `docker-compose.deploy.yml` | web + backend のみ |
| `.env.deploy.example` | デプロイ用環境変数テンプレート |
| `metro.config.js` | @supabase/* CJS 強制解決 |

## Test plan
- [x] `docker compose config` で構文エラーなし
- [x] `docker compose -f docker-compose.deploy.yml config` で構文エラーなし
- [x] `docker compose up -d` で web サービスが起動しないことを確認
- [x] `docker compose --profile web up` で web サービスが起動することを確認
- [x] `pnpm web` で http://localhost:8081 が正常表示されることを確認
- [x] ブラウザコンソールに `import.meta` エラーが出ないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)