### PR TITLE
fix: Web版メニューが他のカードに隠れる問題を修正

### DIFF
--- a/src/components/habits/HabitCardActions.web.tsx
+++ b/src/components/habits/HabitCardActions.web.tsx
@@ -45,7 +45,7 @@ export function HabitCardActions({
   }, [onUnskip]);
 
   return (
-    <View style={styles.wrapper}>
+    <View style={[styles.wrapper, open && styles.wrapperOpen]}>
       {children}
 
       {/* カード右端に絶対配置されるメニュー */}
@@ -102,6 +102,10 @@ export function HabitCardActions({
 const styles = StyleSheet.create({
   wrapper: {
     position: 'relative',
+    zIndex: 1,
+  },
+  wrapperOpen: {
+    zIndex: 9999,
   },
   menuAnchor: {
     position: 'absolute',


### PR DESCRIPTION
## Summary
- Web版のHabitCard三点メニュー（⋮）が、下のカードの stacking context に隠れてクリックできない問題を修正
- メニュー展開時に wrapper の `zIndex` を動的に `9999` に設定し、他のカードより上に表示されるようにした

## Root cause
各カードの wrapper が `position: relative` で独立した stacking context を作るため、後から描画されるカード（下のカード）が前のカードの dropdown を覆っていた

## Test plan
- [x] `pnpm test` — 270 tests passed
- [x] Web でメニューボタンをクリック → ドロップダウンが他のカードの上に表示される
- [x] メニュー項目をクリック → 正常に動作する
- [x] overlay をクリック → メニューが閉じる

🤖 Generated with [Claude Code](https://claude.com/claude-code)