### PR TITLE
fix: Today画面で習慣の開始日より前の日付に表示されるバグを修正

### DIFF
--- a/src/state/queries/__tests__/habits.test.ts
+++ b/src/state/queries/__tests__/habits.test.ts
@@ -309,6 +309,59 @@ describe('habits queries', () => {
       expect(mockFrom).not.toHaveBeenCalledWith('habits_with_today_log');
     });
 
+    describe('start_date filtering', () => {
+      it('should exclude habits whose start_date is after the target date', async () => {
+        const habit = createMockHabit({
+          id: 'habit-future',
+          start_date: '2024-06-01',
+          recurrence_rule: null,
+        });
+        setupMockChain({data: [habit], error: null}, {data: [], error: null});
+
+        // 2024-01-01 is before start_date 2024-06-01
+        const result = (await executeQueryFn('2024-01-01')) as Array<{id: string}>;
+        expect(result).toHaveLength(0);
+      });
+
+      it('should include habits on their start_date', async () => {
+        const habit = createMockHabit({
+          id: 'habit-today',
+          start_date: '2024-06-01',
+          recurrence_rule: null,
+        });
+        setupMockChain({data: [habit], error: null}, {data: [], error: null});
+
+        const result = (await executeQueryFn('2024-06-01')) as Array<{id: string}>;
+        expect(result).toHaveLength(1);
+        expect(result[0].id).toBe('habit-today');
+      });
+
+      it('should include habits after their start_date', async () => {
+        const habit = createMockHabit({
+          id: 'habit-past',
+          start_date: '2024-01-01',
+          recurrence_rule: null,
+        });
+        setupMockChain({data: [habit], error: null}, {data: [], error: null});
+
+        const result = (await executeQueryFn('2024-06-01')) as Array<{id: string}>;
+        expect(result).toHaveLength(1);
+      });
+
+      it('should exclude habits with recurrence_rule before start_date', async () => {
+        const habit = createMockHabit({
+          id: 'habit-rrule-future',
+          start_date: '2024-06-01',
+          recurrence_rule: 'RRULE:FREQ=WEEKLY;BYDAY=MO',
+        });
+        setupMockChain({data: [habit], error: null}, {data: [], error: null});
+
+        // Monday 2024-01-01 matches MO, but is before start_date
+        const result = (await executeQueryFn('2024-01-01')) as Array<{id: string}>;
+        expect(result).toHaveLength(0);
+      });
+    });
+
     describe('recurrence filtering', () => {
       it('should include habits without recurrence rule', async () => {
         const habit = createMockHabit({recurrence_rule: null});

--- a/src/state/queries/habits.ts
+++ b/src/state/queries/habits.ts
@@ -68,9 +68,11 @@ export function useHabitsWithLog(date?: string) {
 
       if (logsError) throw logsError;
 
-      // 繰り返しルールに基づいてフィルタリング
+      // 開始日・繰り返しルールに基づいてフィルタリング
       const targetDateObj = new Date(targetDate);
       const filteredHabits = habits.filter(h => {
+        // 開始日より前の日付では表示しない
+        if (targetDate < h.start_date) return false;
         if (!h.recurrence_rule) return true;
         return isDateMatchingRRule(
           h.recurrence_rule,


### PR DESCRIPTION
## Summary
- `useHabitsWithLog` で習慣の `start_date` が無視されており、開始日より前の日付でも習慣が表示されていた
- `targetDate < h.start_date` チェックを追加し、開始日より前の日付では非表示にする
- 4件のテストケースを追加（開始日前/当日/後、recurrence_rule付きの開始日前）

## Test plan
- [x] `pnpm test` — 全 388 テスト通過
- [x] `pnpm lint` — エラーなし
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm intl:check` — 翻訳完備
- [ ] Web/iOS で日付を開始日より前に切り替え → 該当習慣が非表示になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)