### PR TITLE
fix: 日付切り替え時のDateStripスクロールリセットと白画面を修正

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -83,60 +83,26 @@ export default function TodayScreen() {
   // 時間帯ごとに習慣をグループ化
   const groupedHabits = groupHabitsByTimeOfDay(habits ?? []);
 
-  if (isLoading) {
-    return (
-      <SafeAreaView style={styles.container} edges={['top']}>
+  // コンテンツ部分の描画（ヘッダーは常に表示、ここだけ切り替え）
+  const renderContent = () => {
+    if (isLoading && !habits) {
+      return (
         <View style={styles.loadingContainer}>
           <ActivityIndicator size="large" color={colors.primary[500]} />
         </View>
-      </SafeAreaView>
-    );
-  }
+      );
+    }
 
-  if (error) {
-    return (
-      <SafeAreaView style={styles.container} edges={['top']}>
+    if (error && !habits) {
+      return (
         <View style={styles.errorContainer}>
           <Text style={styles.errorText}>{_(msg`Failed to load habits`)}</Text>
           <Text style={styles.errorSubtext}>{_(msg`Please try again`)}</Text>
         </View>
-      </SafeAreaView>
-    );
-  }
+      );
+    }
 
-  return (
-    <SafeAreaView style={styles.container} edges={['top']}>
-      {/* ヘッダー */}
-      <View style={styles.header}>
-        <View style={styles.headerTop}>
-          <Text style={styles.title}>{headerTitle}</Text>
-          <Pressable
-            style={styles.addButton}
-            onPress={() => router.navigate('/habit/new')}
-          >
-            <Text style={styles.addButtonText}>+</Text>
-          </Pressable>
-        </View>
-
-        {/* 日付ストリップ */}
-        <DateStrip
-          selectedDate={selectedDate}
-          onSelectDate={setSelectedDate}
-        />
-
-        {/* 進捗 */}
-        <View style={styles.progressContainer}>
-          <Text style={styles.progressText}>
-            {completedCount}/{effectiveTotal} {_(msg`completed`)}
-          </Text>
-          <View style={styles.progressBar}>
-            <View style={[styles.progressFill, {width: `${progress}%`}]} />
-          </View>
-          <Text style={styles.progressPercent}>{Math.round(progress)}%</Text>
-        </View>
-      </View>
-
-      {/* 習慣リスト */}
+    return (
       <ScrollView
         style={styles.scrollView}
         contentContainerStyle={styles.scrollContent}
@@ -194,6 +160,43 @@ export default function TodayScreen() {
           </>
         )}
       </ScrollView>
+    );
+  };
+
+  return (
+    <SafeAreaView style={styles.container} edges={['top']}>
+      {/* ヘッダー（常に表示） */}
+      <View style={styles.header}>
+        <View style={styles.headerTop}>
+          <Text style={styles.title}>{headerTitle}</Text>
+          <Pressable
+            style={styles.addButton}
+            onPress={() => router.navigate('/habit/new')}
+          >
+            <Text style={styles.addButtonText}>+</Text>
+          </Pressable>
+        </View>
+
+        {/* 日付ストリップ */}
+        <DateStrip
+          selectedDate={selectedDate}
+          onSelectDate={setSelectedDate}
+        />
+
+        {/* 進捗 */}
+        <View style={styles.progressContainer}>
+          <Text style={styles.progressText}>
+            {completedCount}/{effectiveTotal} {_(msg`completed`)}
+          </Text>
+          <View style={styles.progressBar}>
+            <View style={[styles.progressFill, {width: `${progress}%`}]} />
+          </View>
+          <Text style={styles.progressPercent}>{Math.round(progress)}%</Text>
+        </View>
+      </View>
+
+      {/* 習慣リスト */}
+      {renderContent()}
     </SafeAreaView>
   );
 }

--- a/src/state/queries/habits.ts
+++ b/src/state/queries/habits.ts
@@ -1,4 +1,4 @@
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient, keepPreviousData } from '@tanstack/react-query';
 import { supabase } from '@/lib/supabase';
 import { isDateMatchingRRule } from '@/lib/recurrence';
 import type {
@@ -99,6 +99,7 @@ export function useHabitsWithLog(date?: string) {
         } as HabitWithLog;
       });
     },
+    placeholderData: keepPreviousData,
   });
 }
 


### PR DESCRIPTION
## Summary
- `useHabitsWithLog` に `keepPreviousData` を追加し、日付切り替え時に前のデータを表示し続けることで白画面フラッシュを解消
- ヘッダー（タイトル・DateStrip・進捗バー）を常にマウント状態に変更し、ローディング/エラー表示はコンテンツ部分のみに限定
- DateStrip がアンマウント→再マウントされなくなるため、横スクロール位置が維持される

## Test plan
- [x] `pnpm test` — 全 388 テスト通過
- [x] `pnpm lint` — エラーなし
- [x] `pnpm typecheck` — エラーなし
- [x] `pnpm intl:check` — 翻訳完備
- [x] Web で日付切り替え時に白画面フラッシュが出ないことを確認
- [x] Web で左端の日付をクリックしてもDateStripのスクロール位置がリセットされないことを確認
- [ ] iOS で同様の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)