### PR TITLE
feat: show streak badge only within streak date range

### DIFF
--- a/app/(tabs)/habits.tsx
+++ b/app/(tabs)/habits.tsx
@@ -1,4 +1,4 @@
-import { useState, useMemo, useCallback } from 'react';
+import { useState, useMemo, useCallback, useRef } from 'react';
 import {
   View,
   Text,
@@ -67,6 +67,13 @@ export default function HabitsScreen() {
     return {habitIds: ids, habitInfos: infos};
   }, [habits]);
   const {data: streaks} = useHabitStreaks(habitIds, habitInfos);
+
+  // ストリークデータを安定化（クエリ再取得中の一時的な undefined を防ぐ）
+  const lastStreaksRef = useRef(streaks);
+  if (streaks) {
+    lastStreaksRef.current = streaks;
+  }
+  const stableStreaks = streaks ?? lastStreaksRef.current;
 
   // 検索フィルタリング
   const filteredHabits = useMemo(() => {
@@ -255,7 +262,7 @@ export default function HabitsScreen() {
                       >
                         <HabitListItem
                           habit={habit}
-                          streak={streaks?.[habit.id] ?? 0}
+                          streak={stableStreaks?.[habit.id]?.count ?? 0}
                           onPress={handlePressHabit}
                           isArchived={habit.status === 'archived'}
                           onArchive={() => archiveHabit.mutate(habit.id)}
@@ -290,7 +297,7 @@ export default function HabitsScreen() {
                       >
                         <HabitListItem
                           habit={habit}
-                          streak={streaks?.[habit.id] ?? 0}
+                          streak={stableStreaks?.[habit.id]?.count ?? 0}
                           onPress={handlePressHabit}
                           isArchived={habit.status === 'archived'}
                           onArchive={() => archiveHabit.mutate(habit.id)}

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -1,4 +1,4 @@
-import {useState, useMemo} from 'react';
+import {useState, useMemo, useCallback, useRef} from 'react';
 import {View, Text, StyleSheet, ScrollView, Pressable, ActivityIndicator, RefreshControl} from 'react-native';
 import {msg} from '@lingui/macro';
 import {useLingui} from '@lingui/react';
@@ -51,6 +51,22 @@ export default function TodayScreen() {
     return {habitIds: ids, habitInfos: infos};
   }, [habits]);
   const {data: streaks} = useHabitStreaks(habitIds, habitInfos);
+
+  // ストリークデータを安定化（クエリ再取得中の一時的な undefined を防ぐ）
+  const lastStreaksRef = useRef(streaks);
+  if (streaks) {
+    lastStreaksRef.current = streaks;
+  }
+  const stableStreaks = streaks ?? lastStreaksRef.current;
+
+  // selectedDate がストリーク範囲内のときのみ streak を返す
+  const getStreakForDate = useCallback((habitId: string): number => {
+    const result = stableStreaks?.[habitId];
+    if (!result || result.count === 0 || !result.from) return 0;
+    // from <= selectedDate であればストリーク範囲内
+    if (selectedDate >= result.from) return result.count;
+    return 0;
+  }, [stableStreaks, selectedDate]);
 
   const isSelectedToday = dateIsToday(parseISO(selectedDate));
 
@@ -151,7 +167,7 @@ export default function TodayScreen() {
                     >
                       <HabitCard
                         habit={habit}
-                        streak={streaks?.[habit.id] ?? 0}
+                        streak={getStreakForDate(habit.id)}
                         onToggle={handleToggle}
                         onSkip={() => handleSkip(habit)}
                         onUnskip={() => handleUnskip(habit)}

--- a/src/components/habits/HabitCard.tsx
+++ b/src/components/habits/HabitCard.tsx
@@ -308,7 +308,7 @@ export function HabitCard({
         )}
 
         {/* ストリーク */}
-        <StreakBadge streak={streak} />
+        <StreakBadge streak={streak} inactive={!isCompleted && !isSkipped} />
 
         {/* アクションメニュー（⋮ボタン） */}
         <View style={styles.actionAnchor}>

--- a/src/components/habits/StreakBadge.tsx
+++ b/src/components/habits/StreakBadge.tsx
@@ -9,21 +9,24 @@ interface StreakBadgeProps {
   streak: number;
   /** サイズ */
   size?: 'sm' | 'md';
+  /** 未完了状態（グレー表示） */
+  inactive?: boolean;
 }
 
 /**
  * ストリークバッジコンポーネント
  * 連続達成日数を炎アイコンと共に表示
+ * inactive=true の場合はグレー表示（未チェック状態）
  */
-export function StreakBadge({ streak, size = 'sm' }: StreakBadgeProps) {
+export function StreakBadge({ streak, size = 'sm', inactive = false }: StreakBadgeProps) {
   const { _ } = useLingui();
 
   if (streak <= 0) return null;
 
   return (
     <View style={[styles.container, size === 'md' && styles.containerMd]}>
-      <Text style={[styles.icon, size === 'md' && styles.iconMd]}>🔥</Text>
-      <Text style={[styles.text, size === 'md' && styles.textMd]}>
+      <Text style={[styles.icon, size === 'md' && styles.iconMd, inactive && styles.iconInactive]}>🔥</Text>
+      <Text style={[styles.text, size === 'md' && styles.textMd, inactive && styles.textInactive]}>
         {_(msg`${streak} days`)}
       </Text>
     </View>
@@ -51,5 +54,11 @@ const styles = StyleSheet.create({
   },
   textMd: {
     ...typography.bodySmallMedium,
+  },
+  iconInactive: {
+    opacity: 0.4,
+  },
+  textInactive: {
+    color: colors.gray[400],
   },
 });

--- a/src/lib/__tests__/streak.test.ts
+++ b/src/lib/__tests__/streak.test.ts
@@ -29,20 +29,23 @@ const dailyHabit: StreakHabitInfo = {
 };
 
 describe('calculateStreak', () => {
-  it('ログなし → 0', () => {
-    expect(calculateStreak([], dailyHabit, '2024-03-01')).toBe(0);
+  it('ログなし → count=0, from=null', () => {
+    const result = calculateStreak([], dailyHabit, '2024-03-01');
+    expect(result).toEqual({count: 0, from: null});
   });
 
-  it('今日のみ completed → 1', () => {
+  it('今日のみ completed → count=1, from=今日', () => {
     const logs: StreakLogEntry[] = [
       {target_date: '2024-03-01', status: 'completed'},
     ];
-    expect(calculateStreak(logs, dailyHabit, '2024-03-01')).toBe(1);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-01');
+    expect(result).toEqual({count: 1, from: '2024-03-01'});
   });
 
-  it('3日連続 completed → 3', () => {
+  it('3日連続 completed → count=3, from=最古日', () => {
     const logs = makeConsecutiveLogs('2024-03-03', 3);
-    expect(calculateStreak(logs, dailyHabit, '2024-03-03')).toBe(3);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-03');
+    expect(result).toEqual({count: 3, from: '2024-03-01'});
   });
 
   it('途中にギャップ（ログなし）→ ギャップ前まで', () => {
@@ -53,10 +56,11 @@ describe('calculateStreak', () => {
       {target_date: '2024-03-02', status: 'completed'},
       {target_date: '2024-03-01', status: 'completed'},
     ];
-    expect(calculateStreak(logs, dailyHabit, '2024-03-05')).toBe(2);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-05');
+    expect(result).toEqual({count: 2, from: '2024-03-04'});
   });
 
-  it('途中に skipped → skipped はカウントせずストリーク維持', () => {
+  it('途中に skipped → skipped はカウントせずストリーク維持、from は skipped 含む', () => {
     const logs: StreakLogEntry[] = [
       {target_date: '2024-03-05', status: 'completed'},
       {target_date: '2024-03-04', status: 'skipped'},
@@ -64,12 +68,14 @@ describe('calculateStreak', () => {
       {target_date: '2024-03-02', status: 'completed'},
     ];
     // completed: 3/5, 3/3, 3/2 = 3。skipped(3/4) はカウントしないが途切れない
-    expect(calculateStreak(logs, dailyHabit, '2024-03-05')).toBe(3);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-05');
+    expect(result).toEqual({count: 3, from: '2024-03-02'});
   });
 
-  it('全部 skipped → 0', () => {
+  it('全部 skipped → count=0, from=null', () => {
     const logs = makeConsecutiveLogs('2024-03-03', 3, 'skipped');
-    expect(calculateStreak(logs, dailyHabit, '2024-03-03')).toBe(0);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-03');
+    expect(result).toEqual({count: 0, from: null});
   });
 
   it('週3回の習慣（Mon/Wed/Fri）で非対象日をスキップ', () => {
@@ -86,7 +92,8 @@ describe('calculateStreak', () => {
       {target_date: '2024-03-06', status: 'completed'}, // Wed
       {target_date: '2024-03-04', status: 'completed'}, // Mon
     ];
-    expect(calculateStreak(logs, weeklyHabit, '2024-03-08')).toBe(3);
+    const result = calculateStreak(logs, weeklyHabit, '2024-03-08');
+    expect(result).toEqual({count: 3, from: '2024-03-04'});
   });
 
   it('interval=2 の習慣で非対象日をスキップ', () => {
@@ -101,7 +108,8 @@ describe('calculateStreak', () => {
       {target_date: '2024-03-03', status: 'completed'},
       {target_date: '2024-03-01', status: 'completed'},
     ];
-    expect(calculateStreak(logs, intervalHabit, '2024-03-07')).toBe(4);
+    const result = calculateStreak(logs, intervalHabit, '2024-03-07');
+    expect(result).toEqual({count: 4, from: '2024-03-01'});
   });
 
   it('start_date 以前は走査しない', () => {
@@ -116,23 +124,26 @@ describe('calculateStreak', () => {
       // 3/2 以前にもログがあるが start_date 以前なので走査しない
       {target_date: '2024-03-02', status: 'completed'},
     ];
-    expect(calculateStreak(logs, habit, '2024-03-05')).toBe(3);
+    const result = calculateStreak(logs, habit, '2024-03-05');
+    expect(result).toEqual({count: 3, from: '2024-03-03'});
   });
 
-  it('今日にログがなく過去にログがある場合 → 0', () => {
+  it('今日にログがなく過去にログがある場合 → count=0', () => {
     const logs: StreakLogEntry[] = [
       {target_date: '2024-03-01', status: 'completed'},
       {target_date: '2024-02-29', status: 'completed'},
     ];
-    expect(calculateStreak(logs, dailyHabit, '2024-03-02')).toBe(0);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-02');
+    expect(result).toEqual({count: 0, from: null});
   });
 
-  it('今日が skipped で昨日が completed → 1', () => {
+  it('今日が skipped で昨日が completed → count=1, from=昨日', () => {
     const logs: StreakLogEntry[] = [
       {target_date: '2024-03-02', status: 'skipped'},
       {target_date: '2024-03-01', status: 'completed'},
     ];
-    expect(calculateStreak(logs, dailyHabit, '2024-03-02')).toBe(1);
+    const result = calculateStreak(logs, dailyHabit, '2024-03-02');
+    expect(result).toEqual({count: 1, from: '2024-03-01'});
   });
 
   it('週次習慣で today が非対象日の場合、直近の対象日から計算', () => {
@@ -146,7 +157,8 @@ describe('calculateStreak', () => {
       {target_date: '2024-03-08', status: 'completed'}, // Fri
       {target_date: '2024-03-06', status: 'completed'}, // Wed
     ];
-    expect(calculateStreak(logs, weeklyHabit, '2024-03-09')).toBe(2);
+    const result = calculateStreak(logs, weeklyHabit, '2024-03-09');
+    expect(result).toEqual({count: 2, from: '2024-03-06'});
   });
 });
 
@@ -165,19 +177,19 @@ describe('calculateStreaks', () => {
 
     const result = calculateStreaks(logsByHabit, habits, '2024-03-05');
     expect(result).toEqual({
-      'habit-1': 5,
-      'habit-2': 2,
-      'habit-3': 0,
+      'habit-1': {count: 5, from: '2024-03-01'},
+      'habit-2': {count: 2, from: '2024-03-04'},
+      'habit-3': {count: 0, from: null},
     });
   });
 
-  it('ログが存在しない習慣IDは 0 を返す', () => {
+  it('ログが存在しない習慣IDは count=0 を返す', () => {
     const logsByHabit: Record<string, StreakLogEntry[]> = {};
     const habits: Record<string, StreakHabitInfo> = {
       'habit-1': {recurrence_rule: null, start_date: '2024-01-01'},
     };
 
     const result = calculateStreaks(logsByHabit, habits, '2024-03-05');
-    expect(result).toEqual({'habit-1': 0});
+    expect(result).toEqual({'habit-1': {count: 0, from: null}});
   });
 });

--- a/src/lib/streak.ts
+++ b/src/lib/streak.ts
@@ -21,6 +21,13 @@ export interface StreakHabitInfo {
   start_date: string;
 }
 
+export interface StreakResult {
+  /** 連続達成日数 */
+  count: number;
+  /** ストリーク開始日（最も古い日）。count=0 の場合は null */
+  from: string | null;
+}
+
 /** 最大遡り日数（安全制限） */
 const MAX_LOOKBACK_DAYS = 365;
 
@@ -63,7 +70,7 @@ export function calculateStreak(
   logs: StreakLogEntry[],
   habit: StreakHabitInfo,
   today?: string,
-): number {
+): StreakResult {
   // ログを Map に変換して O(1) ルックアップ
   const logMap = new Map<string, 'completed' | 'skipped'>();
   for (const log of logs) {
@@ -81,6 +88,7 @@ export function calculateStreak(
 
   let streak = 0;
   let daysChecked = 0;
+  let fromDate: string | null = null;
 
   while (daysChecked < MAX_LOOKBACK_DAYS) {
     const dateStr = formatDate(currentDate);
@@ -99,8 +107,10 @@ export function calculateStreak(
 
     if (status === 'completed') {
       streak++;
+      fromDate = dateStr;
     } else if (status === 'skipped') {
       // skipped はストリーク維持（インクリメントなし）
+      fromDate = dateStr;
     } else {
       // ログなし → ストリーク途切れ
       break;
@@ -110,7 +120,7 @@ export function calculateStreak(
     daysChecked++;
   }
 
-  return streak;
+  return {count: streak, from: streak > 0 ? fromDate : null};
 }
 
 /**
@@ -120,8 +130,8 @@ export function calculateStreaks(
   logsByHabit: Record<string, StreakLogEntry[]>,
   habits: Record<string, StreakHabitInfo>,
   today?: string,
-): Record<string, number> {
-  const result: Record<string, number> = {};
+): Record<string, StreakResult> {
+  const result: Record<string, StreakResult> = {};
 
   for (const habitId of Object.keys(habits)) {
     const logs = logsByHabit[habitId] ?? [];

--- a/src/state/queries/__tests__/streaks.test.ts
+++ b/src/state/queries/__tests__/streaks.test.ts
@@ -86,11 +86,12 @@ describe('streaks queries', () => {
       expect(mockFrom).toHaveBeenCalledWith('habit_logs');
     });
 
-    it('should return streak values for each habit', async () => {
-      const today = new Date().toISOString().split('T')[0];
+    it('should return streak results for each habit', async () => {
+      const now = new Date();
+      const today = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-${String(now.getDate()).padStart(2, '0')}`;
       const yesterday = new Date();
       yesterday.setDate(yesterday.getDate() - 1);
-      const yesterdayStr = yesterday.toISOString().split('T')[0];
+      const yesterdayStr = `${yesterday.getFullYear()}-${String(yesterday.getMonth() + 1).padStart(2, '0')}-${String(yesterday.getDate()).padStart(2, '0')}`;
 
       setupMockChain({
         data: [
@@ -109,12 +110,12 @@ describe('streaks queries', () => {
       const result = await queryFn();
 
       expect(result).toEqual({
-        'habit-1': 2,
-        'habit-2': 1,
+        'habit-1': {count: 2, from: yesterdayStr},
+        'habit-2': {count: 1, from: today},
       });
     });
 
-    it('should return 0 for habits with no logs', async () => {
+    it('should return count=0 for habits with no logs', async () => {
       setupMockChain({data: [], error: null});
 
       const habits: Record<string, StreakHabitInfo> = {
@@ -123,7 +124,7 @@ describe('streaks queries', () => {
       const queryFn = getQueryFn(['habit-1'], habits);
       const result = await queryFn();
 
-      expect(result).toEqual({'habit-1': 0});
+      expect(result).toEqual({'habit-1': {count: 0, from: null}});
     });
 
     it('should throw when supabase returns an error', async () => {
@@ -178,7 +179,7 @@ describe('streaks queries', () => {
       const queryFn = getQueryFn(['habit-1'], habits);
       const result = await queryFn();
 
-      expect(result).toEqual({'habit-1': 0});
+      expect(result).toEqual({'habit-1': {count: 0, from: null}});
     });
   });
 });

--- a/src/state/queries/streaks.ts
+++ b/src/state/queries/streaks.ts
@@ -1,7 +1,9 @@
-import {useQuery} from '@tanstack/react-query';
+import {useQuery, keepPreviousData} from '@tanstack/react-query';
 import {supabase} from '@/lib/supabase';
 import {calculateStreaks} from '@/lib/streak';
-import type {StreakLogEntry, StreakHabitInfo} from '@/lib/streak';
+import type {StreakLogEntry, StreakHabitInfo, StreakResult} from '@/lib/streak';
+
+export type {StreakResult};
 
 // ===========================================
 // Query Keys
@@ -17,14 +19,24 @@ export const streakKeys = {
 // Queries
 // ===========================================
 
+/**
+ * ローカルタイムゾーンの日付を 'YYYY-MM-DD' 形式で返す
+ */
+function formatLocalDate(date: Date): string {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
 export function useHabitStreaks(
   habitIds: string[],
   habits: Record<string, StreakHabitInfo>,
 ) {
-  const today = new Date().toISOString().split('T')[0];
+  const today = formatLocalDate(new Date());
   const from = new Date();
   from.setDate(from.getDate() - 365);
-  const fromDate = from.toISOString().split('T')[0];
+  const fromDate = formatLocalDate(from);
 
   return useQuery({
     queryKey: streakKeys.byHabits(habitIds),
@@ -54,5 +66,6 @@ export function useHabitStreaks(
     },
     enabled: habitIds.length > 0,
     staleTime: 5 * 60 * 1000,
+    placeholderData: keepPreviousData,
   });
 }


### PR DESCRIPTION
## Summary
- `calculateStreak` の戻り値を `StreakResult {count, from}` に拡張し、ストリーク連鎖の開始日を返すように変更
- Today 画面で `selectedDate` がストリーク範囲外（`from` より前の日付）の場合はバッジを非表示に
- `useRef` によるストリークデータの安定化で、クエリ再取得中のバッジ消失（フリッカー）を防止
- 未チェック状態の習慣にはグレーのストリークバッジを表示（inactive スタイル）

## Test plan
- [x] `pnpm test` — 442 tests passed
- [x] `pnpm lint` — no errors
- [x] `pnpm typecheck` — no errors
- [x] `pnpm intl:check` — all translations complete
- [ ] Today 画面でストリーク対象期間内の日付 → バッジ表示確認
- [ ] Today 画面でストリーク対象期間外の日付 → バッジ非表示確認
- [ ] 日付切り替え時にバッジがフリッカーしないことを確認
- [ ] Habits 画面でストリークバッジが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)