### PR TITLE
fix: paginate Supabase query to bypass 1000 row limit

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -50,16 +50,7 @@ export default function TodayScreen() {
     }
     return {habitIds: ids, habitInfos: infos};
   }, [habits]);
-  const {data: streaks, error: streakError, isLoading: streakLoading, fetchStatus: streakFetchStatus} = useHabitStreaks(habitIds, habitInfos);
-
-  console.log('[today] streak query state', {
-    habitIds: habitIds.length,
-    hasData: !!streaks,
-    streakError: streakError?.message ?? null,
-    streakLoading,
-    streakFetchStatus,
-    selectedDate,
-  });
+  const {data: streaks} = useHabitStreaks(habitIds, habitInfos);
 
   // ストリークデータを安定化（クエリ再取得中の一時的な undefined を防ぐ）
   const lastStreaksRef = useRef(streaks);

--- a/src/state/queries/__tests__/streaks.test.ts
+++ b/src/state/queries/__tests__/streaks.test.ts
@@ -39,7 +39,11 @@ function setupMockChain(response: unknown) {
     select: jest.fn().mockReturnValue({
       in: jest.fn().mockReturnValue({
         gte: jest.fn().mockReturnValue({
-          lte: jest.fn<() => Promise<unknown>>().mockResolvedValue(response),
+          lte: jest.fn().mockReturnValue({
+            order: jest.fn().mockReturnValue({
+              range: jest.fn<() => Promise<unknown>>().mockResolvedValue(response),
+            }),
+          }),
         }),
       }),
     }),

--- a/src/state/queries/streaks.ts
+++ b/src/state/queries/streaks.ts
@@ -29,6 +29,46 @@ function formatLocalDate(date: Date): string {
   return `${y}-${m}-${d}`;
 }
 
+/** Supabase のデフォルト行数制限 */
+const PAGE_SIZE = 1000;
+
+/**
+ * Supabase の 1000 行制限を超えるデータをページネーションで全件取得
+ */
+async function fetchAllHabitLogs(
+  habitIds: string[],
+  fromDate: string,
+  today: string,
+) {
+  const allRows: {habit_id: string; target_date: string; status: string}[] = [];
+  let rangeStart = 0;
+  let hasMore = true;
+
+  while (hasMore) {
+    const {data, error} = await supabase
+      .from('habit_logs')
+      .select('habit_id, target_date, status')
+      .in('habit_id', habitIds)
+      .gte('target_date', fromDate)
+      .lte('target_date', today)
+      .order('target_date', {ascending: false})
+      .range(rangeStart, rangeStart + PAGE_SIZE - 1);
+
+    if (error) throw error;
+
+    allRows.push(...(data ?? []));
+
+    // 返却行数が PAGE_SIZE 未満なら全件取得済み
+    if (!data || data.length < PAGE_SIZE) {
+      hasMore = false;
+    } else {
+      rangeStart += PAGE_SIZE;
+    }
+  }
+
+  return allRows;
+}
+
 export function useHabitStreaks(
   habitIds: string[],
   habits: Record<string, StreakHabitInfo>,
@@ -41,25 +81,11 @@ export function useHabitStreaks(
   return useQuery({
     queryKey: streakKeys.byHabits(habitIds),
     queryFn: async () => {
-      console.log('[streaks] queryFn called', {habitCount: habitIds.length, today, fromDate});
-
-      const {data, error} = await supabase
-        .from('habit_logs')
-        .select('habit_id, target_date, status')
-        .in('habit_id', habitIds)
-        .gte('target_date', fromDate)
-        .lte('target_date', today);
-
-      if (error) {
-        console.error('[streaks] Supabase error', error);
-        throw error;
-      }
-
-      console.log('[streaks] Supabase rows:', data?.length ?? 0);
+      const rows = await fetchAllHabitLogs(habitIds, fromDate, today);
 
       // habit_id ごとにログをグルーピング
       const logsByHabit: Record<string, StreakLogEntry[]> = {};
-      for (const row of data ?? []) {
+      for (const row of rows) {
         if (!logsByHabit[row.habit_id]) {
           logsByHabit[row.habit_id] = [];
         }
@@ -69,11 +95,7 @@ export function useHabitStreaks(
         });
       }
 
-      const result = calculateStreaks(logsByHabit, habits, today);
-      const nonZero = Object.entries(result).filter(([, v]) => v.count > 0);
-      console.log('[streaks] result:', {total: Object.keys(result).length, nonZero: nonZero.length, samples: nonZero.slice(0, 3)});
-
-      return result;
+      return calculateStreaks(logsByHabit, habits, today);
     },
     enabled: habitIds.length > 0,
     staleTime: 5 * 60 * 1000,


### PR DESCRIPTION
## Summary
- Supabase のデフォルト行数制限(1000行)により、本番環境でストリークが全て0になるバグを修正
- `fetchAllHabitLogs` 関数でページネーション(`.range()`)を実装し、全件取得を保証
- `.order('target_date', {ascending: false})` を追加し、最新のログから取得
- デバッグログを削除

## Root cause
Supabase はクエリ結果をデフォルトで最大1000行に制限する。5習慣×365日=最大1825行のため、直近のログが切り捨てられていた。ローカル(Docker Supabase)ではデータ量が少なく問題が顕在化しなかった。

## Test plan
- [x] `pnpm test` — 442 tests passed
- [x] `pnpm lint` — no errors
- [x] `pnpm typecheck` — no errors
- [ ] Cloudflare Pages にデプロイ後、ストリークが正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)