### PR TITLE
feat: implement start date picker with native HTML date input

### DIFF
--- a/src/components/forms/HabitForm.tsx
+++ b/src/components/forms/HabitForm.tsx
@@ -9,7 +9,6 @@ import {
 } from 'react-native';
 import { msg } from '@lingui/macro';
 import { useLingui } from '@lingui/react';
-import { Ionicons } from '@expo/vector-icons';
 import {
   Input,
   MultiSelect,
@@ -324,22 +323,30 @@ export function HabitForm({
           required
           error={getFieldError('start_date')}
         >
-          <Pressable
-            style={styles.dateInput}
-            onPress={() => {
-              // TODO: DatePicker を実装
+          <input
+            type="date"
+            value={formData.start_date}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              updateField('start_date', e.target.value);
               touchField('start_date');
             }}
-          >
-            <Ionicons
-              name="calendar-outline"
-              size={20}
-              color={lightTheme.textSecondary}
-            />
-            <Text style={styles.dateText}>
-              {formatDate(formData.start_date)}
-            </Text>
-          </Pressable>
+            style={{
+              backgroundColor: lightTheme.surfaceSecondary,
+              borderRadius: borderRadius.md,
+              paddingTop: spacing.sm,
+              paddingBottom: spacing.sm,
+              paddingLeft: spacing.md,
+              paddingRight: spacing.md,
+              fontSize: 16,
+              lineHeight: '24px',
+              color: lightTheme.text,
+              border: 'none',
+              outline: 'none',
+              fontFamily: '-apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif',
+              width: '100%',
+              boxSizing: 'border-box' as const,
+            }}
+          />
         </FormField>
       </ScrollView>
 
@@ -381,18 +388,6 @@ export function HabitForm({
   );
 }
 
-/**
- * 日付をフォーマット
- */
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr);
-  return date.toLocaleDateString('ja-JP', {
-    year: 'numeric',
-    month: 'long',
-    day: 'numeric',
-  });
-}
-
 const styles = StyleSheet.create({
   container: {
     flex: 1,
@@ -407,19 +402,6 @@ const styles = StyleSheet.create({
     minHeight: 80,
     textAlignVertical: 'top',
     paddingTop: spacing.sm,
-  },
-  dateInput: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: lightTheme.surfaceSecondary,
-    borderRadius: borderRadius.md,
-    paddingVertical: spacing.sm,
-    paddingHorizontal: spacing.md,
-    gap: spacing.sm,
-  },
-  dateText: {
-    ...typography.body,
-    color: lightTheme.text,
   },
   footer: {
     flexDirection: 'row',

--- a/src/components/forms/__tests__/HabitForm.test.tsx
+++ b/src/components/forms/__tests__/HabitForm.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react-native';
 import { HabitForm } from '../HabitForm';
 import type { HabitSubmitData } from '../HabitForm';
 
@@ -88,6 +88,22 @@ describe('HabitForm', () => {
       expect(screen.getByDisplayValue('Test Description')).toBeTruthy();
     });
 
+    it('should render start date input with initial value', () => {
+      const { root } = render(
+        <HabitForm
+          initialValues={{
+            name: 'Test Habit',
+            start_date: '2025-06-15',
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      const dateInput = root.findAll((node: {type: string | React.ComponentType}) => node.type === 'input')[0];
+      expect(dateInput.props.value).toBe('2025-06-15');
+    });
+
     it('should parse recurrence_rule for editing', () => {
       render(
         <HabitForm
@@ -136,6 +152,40 @@ describe('HabitForm', () => {
       await waitFor(() => {
         expect(screen.getByText('習慣名を入力してください')).toBeTruthy();
       });
+    });
+  });
+
+  describe('start date', () => {
+    it('should update start date when date is changed', async () => {
+      mockOnSubmit.mockResolvedValue(undefined);
+
+      const { root } = render(
+        <HabitForm
+          initialValues={{
+            start_date: '2025-01-01',
+          }}
+          onSubmit={mockOnSubmit}
+          onCancel={mockOnCancel}
+        />
+      );
+
+      // Change the date via the native input's onChange handler
+      const dateInput = root.findAll((node: {type: string | React.ComponentType}) => node.type === 'input')[0];
+      act(() => {
+        dateInput.props.onChange({ target: { value: '2025-06-15' } });
+      });
+
+      // Fill in required name field and submit
+      const nameInput = screen.getByPlaceholderText('e.g., Reading, Exercise, Meditation');
+      fireEvent.changeText(nameInput, 'Test Habit');
+      fireEvent.press(screen.getByText('Save'));
+
+      await waitFor(() => {
+        expect(mockOnSubmit).toHaveBeenCalledTimes(1);
+      });
+
+      const submittedData = mockOnSubmit.mock.calls[0][0];
+      expect(submittedData.start_date).toBe('2025-06-15');
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace non-functional `Pressable` placeholder with browser-native `<input type="date">` for the habit start date field
- Remove unused `formatDate()` helper, `Ionicons` import, and related `StyleSheet` entries (`dateInput`, `dateText`)
- Add tests for initial value rendering and date change behavior

## Test plan
- [x] `pnpm test` — 492 tests passed (37 suites)
- [x] `pnpm lint` — no errors
- [x] `pnpm typecheck` — no errors
- [x] `pnpm intl:check` — all 136 translations present
- [x] Manual: `pnpm web` → habit create screen → click start date → browser calendar opens → date can be changed
- [x] Manual: habit edit screen → existing start date displayed correctly → can be changed and saved

🤖 Generated with [Claude Code](https://claude.com/claude-code)