### PR TITLE
feat: Habitify インポート機能を API v2 に対応

### DIFF
--- a/app/import/__tests__/habitify.test.tsx
+++ b/app/import/__tests__/habitify.test.tsx
@@ -88,7 +88,6 @@ describe('HabitifyImportScreen', () => {
         api_key: 'my-api-key',
         import_habits: true,
         import_logs: true,
-        timezone: expect.any(String),
       });
     });
   });

--- a/app/import/habitify.tsx
+++ b/app/import/habitify.tsx
@@ -47,7 +47,6 @@ export default function HabitifyImportScreen() {
         api_key: apiKey,
         import_habits: importHabits,
         import_logs: importLogs,
-        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
       });
       setResult(importResult);
       setScreenState('success');

--- a/src/lib/__tests__/backend-api.test.ts
+++ b/src/lib/__tests__/backend-api.test.ts
@@ -37,7 +37,6 @@ describe('importFromHabitify', () => {
       api_key: 'habitify-api-key',
       import_habits: true,
       import_logs: true,
-      timezone: 'Asia/Tokyo',
     });
 
     expect(mockRunImport).toHaveBeenCalledWith(
@@ -45,7 +44,6 @@ describe('importFromHabitify', () => {
         apiKey: 'habitify-api-key',
         importHabits: true,
         importLogs: true,
-        timezone: 'Asia/Tokyo',
         userId: 'user-123',
       }),
     );
@@ -69,7 +67,6 @@ describe('importFromHabitify', () => {
       api_key: 'key',
       import_habits: true,
       import_logs: true,
-      timezone: 'UTC',
     });
 
     expect(result.errors).toEqual(['habit "X": DB error']);
@@ -85,7 +82,6 @@ describe('importFromHabitify', () => {
         api_key: 'key',
         import_habits: true,
         import_logs: true,
-        timezone: 'Asia/Tokyo',
       }),
     ).rejects.toThrow('Not authenticated');
   });
@@ -100,7 +96,6 @@ describe('importFromHabitify', () => {
         api_key: 'bad-key',
         import_habits: true,
         import_logs: true,
-        timezone: 'Asia/Tokyo',
       }),
     ).rejects.toThrow('get habits: status 401');
   });

--- a/src/lib/backend-api.ts
+++ b/src/lib/backend-api.ts
@@ -5,7 +5,6 @@ export interface ImportHabitifyParams {
   api_key: string;
   import_habits: boolean;
   import_logs: boolean;
-  timezone: string;
 }
 
 export interface ImportHabitifyResult {
@@ -28,7 +27,6 @@ export async function importFromHabitify(
     apiKey: params.api_key,
     importHabits: params.import_habits,
     importLogs: params.import_logs,
-    timezone: params.timezone,
     userId,
     supabase,
   });

--- a/src/lib/habitify/__tests__/client.test.ts
+++ b/src/lib/habitify/__tests__/client.test.ts
@@ -4,7 +4,7 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
 global.fetch = mockFetch;
 
-import { getHabits, getLogs, validate, formatHabitifyDate } from '../client';
+import { getHabits, getStatistics, validate, formatDate } from '../client';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return {
@@ -15,54 +15,70 @@ function jsonResponse(body: unknown, status = 200): Response {
   } as Response;
 }
 
-describe('Habitify API client', () => {
+const sampleHabitV2 = {
+  id: 'habit-1',
+  name: 'Morning Run',
+  icon: null,
+  colorHex: '#FF6B6B',
+  type: 'good',
+  description: null,
+  occurrence: { type: 'daily' },
+  startDate: '2024-01-01',
+  createdAt: '2024-01-01T00:00:00Z',
+  isArchived: false,
+  logMethod: 'manual',
+  goals: [
+    {
+      id: 'goal-1',
+      createdAt: '2024-01-01T00:00:00Z',
+      periodicity: 'daily',
+      value: 1,
+      unit: 'rep',
+      isActive: true,
+    },
+  ],
+  areas: [{ id: 'area-1', name: 'Health' }],
+  timeOfDays: [{ id: 'tod-1', name: 'Morning' }],
+};
+
+describe('Habitify API v2 client', () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   describe('getHabits', () => {
-    it('should fetch habits with correct auth header', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'OK',
-          data: [
-            {
-              id: 'habit-1',
-              name: 'Morning Run',
-              is_archived: false,
-              start_date: '2024-01-01T00:00:00+00:00',
-              time_of_day: ['morning'],
-              area: { id: 'area-1', name: 'Health' },
-              recurrence: 'RRULE:FREQ=DAILY',
-              goal: { unit_type: 'count', value: 1, periodicity: 'daily' },
-              log_method: 'check',
-              priority: 1,
-              created_date: '2024-01-01T00:00:00+00:00',
-            },
-          ],
-          status: true,
-          version: 'v1.2',
-        }),
-      );
+    it('should fetch habits with X-API-Key header', async () => {
+      // First call: active habits, second call: archived habits
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [sampleHabitV2],
+            pagination: { total: 1, limit: 100, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [],
+            pagination: { total: 0, limit: 100, offset: 0 },
+          }),
+        );
 
       const habits = await getHabits('test-api-key', 'http://localhost:9999');
 
-      expect(mockFetch).toHaveBeenCalledWith('http://localhost:9999/habits', {
-        method: 'GET',
-        headers: { Authorization: 'test-api-key' },
-      });
+      expect(mockFetch).toHaveBeenCalledWith(
+        expect.stringContaining('http://localhost:9999/habits?'),
+        {
+          method: 'GET',
+          headers: { 'X-API-Key': 'test-api-key' },
+        },
+      );
 
       expect(habits).toHaveLength(1);
       expect(habits[0].id).toBe('habit-1');
       expect(habits[0].name).toBe('Morning Run');
-      expect(habits[0].is_archived).toBe(false);
-      expect(habits[0].area).toEqual({ id: 'area-1', name: 'Health' });
-      expect(habits[0].goal).toEqual({
-        unit_type: 'count',
-        value: 1,
-        periodicity: 'daily',
-      });
-      expect(habits[0].log_method).toBe('check');
+      expect(habits[0].isArchived).toBe(false);
+      expect(habits[0].areas).toEqual([{ id: 'area-1', name: 'Health' }]);
+      expect(habits[0].goals).toHaveLength(1);
     });
 
     it('should throw on unauthorized response', async () => {
@@ -73,64 +89,80 @@ describe('Habitify API client', () => {
       ).rejects.toThrow('get habits: status 401');
     });
 
-    it('should handle null area and null goal', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'OK',
-          data: [
-            {
-              id: 'habit-1',
-              name: 'Read',
-              is_archived: false,
-              start_date: '2024-01-01T00:00:00+00:00',
-              time_of_day: [],
-              area: null,
-              recurrence: 'RRULE:FREQ=DAILY',
-              goal: null,
-              log_method: 'check',
-              priority: 0,
-              created_date: '2024-01-01T00:00:00+00:00',
-            },
-          ],
-          status: true,
-          version: 'v1.2',
-        }),
-      );
+    it('should handle pagination (multiple pages)', async () => {
+      // Page 1 of active habits: 100 items
+      const page1 = Array.from({ length: 100 }, (_, i) => ({
+        ...sampleHabitV2,
+        id: `habit-${i}`,
+      }));
+      // Page 2 of active habits: 10 items
+      const page2 = Array.from({ length: 10 }, (_, i) => ({
+        ...sampleHabitV2,
+        id: `habit-${100 + i}`,
+      }));
+
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: page1,
+            pagination: { total: 110, limit: 100, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: page2,
+            pagination: { total: 110, limit: 100, offset: 100 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [],
+            pagination: { total: 0, limit: 100, offset: 0 },
+          }),
+        );
 
       const habits = await getHabits('test-api-key', 'http://localhost:9999');
 
-      expect(habits).toHaveLength(1);
-      expect(habits[0].area).toBeNull();
-      expect(habits[0].goal).toBeNull();
+      expect(habits).toHaveLength(110);
+      expect(mockFetch).toHaveBeenCalledTimes(3); // 2 pages active + 1 page archived
     });
 
-    it('should throw on API error (status false)', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'Invalid API key',
-          data: null,
-          status: false,
-          version: 'v1.2',
-        }),
-      );
+    it('should fetch both active and archived habits', async () => {
+      const activeHabit = { ...sampleHabitV2, id: 'active-1', isArchived: false };
+      const archivedHabit = { ...sampleHabitV2, id: 'archived-1', isArchived: true };
 
-      await expect(
-        getHabits('test-api-key', 'http://localhost:9999'),
-      ).rejects.toThrow('get habits: API returned error: Invalid API key');
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [activeHabit],
+            pagination: { total: 1, limit: 100, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [archivedHabit],
+            pagination: { total: 1, limit: 100, offset: 0 },
+          }),
+        );
+
+      const habits = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(habits).toHaveLength(2);
+      expect(habits[0].id).toBe('active-1');
+      expect(habits[1].id).toBe('archived-1');
+
+      // Verify first call is for active, second for archived
+      const url1 = (mockFetch.mock.calls[0] as [string])[0];
+      const url2 = (mockFetch.mock.calls[1] as [string])[0];
+      expect(url1).toContain('archived=false');
+      expect(url2).toContain('archived=true');
     });
 
     it('should throw on malformed habit data (Zod validation)', async () => {
       mockFetch.mockResolvedValue(
         jsonResponse({
-          message: 'OK',
-          data: [
-            {
-              // missing required fields like id, name, etc.
-              is_archived: 'not-a-boolean',
-            },
-          ],
-          status: true,
-          version: 'v1.2',
+          data: [{ is_archived: 'not-a-boolean' }],
+          pagination: { total: 1, limit: 100, offset: 0 },
         }),
       );
 
@@ -140,132 +172,81 @@ describe('Habitify API client', () => {
     });
   });
 
-  describe('getLogs', () => {
-    it('should fetch logs with correct path and query parameters', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'OK',
-          data: [
-            {
-              id: 'log-1',
-              habit_id: 'habit-1',
-              value: 1,
-              created_date: '2024-01-15T10:30:00+00:00',
-              unit_type: 'count',
-            },
-            {
-              id: 'log-2',
-              habit_id: 'habit-1',
-              value: 2.5,
-              created_date: '2024-01-16T08:00:00+00:00',
-              unit_type: 'count',
-            },
-          ],
-          status: true,
-          version: 'v1.2',
-        }),
-      );
+  describe('getStatistics', () => {
+    const sampleStats = {
+      id: 'habit-1',
+      name: 'Morning Run',
+      type: 'good',
+      totalLogs: 10,
+      skips: 2,
+      fails: 1,
+      completions: 7,
+      unit: { id: 'unit-1', name: 'Repetition', symbol: 'rep' },
+      periodicity: 'daily',
+      avg: 1.5,
+      dailyProgress: [
+        { date: '2024-01-15', totalLog: 1, status: 'completed' },
+        { date: '2024-01-16', totalLog: 0, status: 'skipped' },
+      ],
+    };
 
-      const from = new Date('2024-01-01T00:00:00Z');
-      const to = new Date('2024-01-31T00:00:00Z');
+    it('should fetch statistics with correct path', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ data: sampleStats }));
 
-      const logs = await getLogs(
+      const stats = await getStatistics(
         'test-api-key',
         'habit-1',
-        from,
-        to,
+        '2024-01-01',
+        '2024-01-31',
         'http://localhost:9999',
       );
 
-      expect(mockFetch).toHaveBeenCalledTimes(1);
       const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
-      expect(calledUrl).toContain('http://localhost:9999/logs/habit-1?');
-      expect(calledUrl).toContain('from=');
-      expect(calledUrl).toContain('to=');
+      expect(calledUrl).toContain('/habits/habit-1/statistics');
+      expect(calledUrl).toContain('startDate=2024-01-01');
+      expect(calledUrl).toContain('endDate=2024-01-31');
 
-      expect(logs).toHaveLength(2);
-      expect(logs[0].id).toBe('log-1');
-      expect(logs[0].value).toBe(1);
-      expect(logs[1].value).toBe(2.5);
+      expect(stats.dailyProgress).toHaveLength(2);
+      expect(stats.completions).toBe(7);
+    });
+
+    it('should work without date parameters', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ data: sampleStats }));
+
+      await getStatistics('test-api-key', 'habit-1', undefined, undefined, 'http://localhost:9999');
+
+      const calledUrl = (mockFetch.mock.calls[0] as [string])[0];
+      expect(calledUrl).toBe('http://localhost:9999/habits/habit-1/statistics');
     });
 
     it('should throw on error response', async () => {
       mockFetch.mockResolvedValue(jsonResponse('', 500));
 
       await expect(
-        getLogs(
-          'test-api-key',
-          'habit-1',
-          new Date(),
-          new Date(),
-          'http://localhost:9999',
-        ),
-      ).rejects.toThrow('get logs for habit habit-1: status 500');
+        getStatistics('test-api-key', 'habit-1', undefined, undefined, 'http://localhost:9999'),
+      ).rejects.toThrow('get statistics for habit habit-1: status 500');
     });
 
-    it('should throw on API error (status false)', async () => {
+    it('should throw on malformed statistics data', async () => {
       mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'Not found',
-          data: null,
-          status: false,
-          version: 'v1.2',
-        }),
+        jsonResponse({ data: { id: 'h-1' } }),
       );
 
       await expect(
-        getLogs(
-          'test-api-key',
-          'habit-1',
-          new Date(),
-          new Date(),
-          'http://localhost:9999',
-        ),
-      ).rejects.toThrow(
-        'get logs for habit habit-1: API returned error: Not found',
-      );
-    });
-
-    it('should throw on malformed log data (Zod validation)', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'OK',
-          data: [
-            {
-              id: 'log-1',
-              // missing habit_id, value is wrong type
-              value: 'not-a-number',
-              created_date: '2024-01-15T10:30:00+00:00',
-              unit_type: 'count',
-            },
-          ],
-          status: true,
-          version: 'v1.2',
-        }),
-      );
-
-      await expect(
-        getLogs(
-          'test-api-key',
-          'habit-1',
-          new Date(),
-          new Date(),
-          'http://localhost:9999',
-        ),
+        getStatistics('test-api-key', 'habit-1', undefined, undefined, 'http://localhost:9999'),
       ).rejects.toThrow();
     });
   });
 
   describe('validate', () => {
     it('should succeed when getHabits succeeds', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          message: 'OK',
-          data: [],
-          status: true,
-          version: 'v1.2',
-        }),
-      );
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [], pagination: { total: 0, limit: 100, offset: 0 } }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ data: [], pagination: { total: 0, limit: 100, offset: 0 } }),
+        );
 
       await expect(
         validate('test-api-key', 'http://localhost:9999'),
@@ -281,14 +262,15 @@ describe('Habitify API client', () => {
     });
   });
 
-  describe('formatHabitifyDate', () => {
-    it('should format a UTC date with +00:00 offset (not Z)', () => {
-      const date = new Date('2024-01-15T10:30:00Z');
-      const formatted = formatHabitifyDate(date);
-      // Should not contain "Z"
-      expect(formatted).not.toContain('Z');
-      // Should contain ±hh:mm offset
-      expect(formatted).toMatch(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/);
+  describe('formatDate', () => {
+    it('should format a date as YYYY-MM-DD', () => {
+      const date = new Date(2024, 0, 15); // Jan 15, 2024
+      expect(formatDate(date)).toBe('2024-01-15');
+    });
+
+    it('should pad single-digit month and day', () => {
+      const date = new Date(2024, 2, 5); // Mar 5, 2024
+      expect(formatDate(date)).toBe('2024-03-05');
     });
   });
 });

--- a/src/lib/habitify/__tests__/client.test.ts
+++ b/src/lib/habitify/__tests__/client.test.ts
@@ -4,15 +4,28 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 const mockFetch = jest.fn() as jest.MockedFunction<typeof fetch>;
 global.fetch = mockFetch;
 
-import { getHabits, getStatistics, validate, formatDate } from '../client';
+import {
+  getHabits,
+  getStatistics,
+  validate,
+  formatDate,
+  __setRetrySleepForTesting,
+} from '../client';
 
-function jsonResponse(body: unknown, status = 200): Response {
+function jsonResponse(
+  body: unknown,
+  status = 200,
+  headers: Record<string, string> = {},
+): Response {
   return {
     ok: status >= 200 && status < 300,
     status,
     json: () => Promise.resolve(body),
     text: () => Promise.resolve(JSON.stringify(body)),
-  } as Response;
+    headers: {
+      get: (name: string) => headers[name] ?? null,
+    },
+  } as unknown as Response;
 }
 
 const sampleHabitV2 = {
@@ -44,6 +57,8 @@ const sampleHabitV2 = {
 describe('Habitify API v2 client', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Avoid real delays in retry-backoff tests.
+    __setRetrySleepForTesting(() => Promise.resolve());
   });
 
   describe('getHabits', () => {
@@ -63,7 +78,7 @@ describe('Habitify API v2 client', () => {
           }),
         );
 
-      const habits = await getHabits('test-api-key', 'http://localhost:9999');
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
 
       expect(mockFetch).toHaveBeenCalledWith(
         expect.stringContaining('http://localhost:9999/habits?'),
@@ -73,12 +88,13 @@ describe('Habitify API v2 client', () => {
         },
       );
 
-      expect(habits).toHaveLength(1);
-      expect(habits[0].id).toBe('habit-1');
-      expect(habits[0].name).toBe('Morning Run');
-      expect(habits[0].isArchived).toBe(false);
-      expect(habits[0].areas).toEqual([{ id: 'area-1', name: 'Health' }]);
-      expect(habits[0].goals).toHaveLength(1);
+      expect(result.errors).toEqual([]);
+      expect(result.habits).toHaveLength(1);
+      expect(result.habits[0].id).toBe('habit-1');
+      expect(result.habits[0].name).toBe('Morning Run');
+      expect(result.habits[0].isArchived).toBe(false);
+      expect(result.habits[0].areas).toEqual([{ id: 'area-1', name: 'Health' }]);
+      expect(result.habits[0].goals).toHaveLength(1);
     });
 
     it('should throw on unauthorized response', async () => {
@@ -121,9 +137,10 @@ describe('Habitify API v2 client', () => {
           }),
         );
 
-      const habits = await getHabits('test-api-key', 'http://localhost:9999');
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
 
-      expect(habits).toHaveLength(110);
+      expect(result.habits).toHaveLength(110);
+      expect(result.errors).toEqual([]);
       expect(mockFetch).toHaveBeenCalledTimes(3); // 2 pages active + 1 page archived
     });
 
@@ -145,11 +162,11 @@ describe('Habitify API v2 client', () => {
           }),
         );
 
-      const habits = await getHabits('test-api-key', 'http://localhost:9999');
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
 
-      expect(habits).toHaveLength(2);
-      expect(habits[0].id).toBe('active-1');
-      expect(habits[1].id).toBe('archived-1');
+      expect(result.habits).toHaveLength(2);
+      expect(result.habits[0].id).toBe('active-1');
+      expect(result.habits[1].id).toBe('archived-1');
 
       // Verify first call is for active, second for archived
       const url1 = (mockFetch.mock.calls[0] as [string])[0];
@@ -158,17 +175,65 @@ describe('Habitify API v2 client', () => {
       expect(url2).toContain('archived=true');
     });
 
-    it('should throw on malformed habit data (Zod validation)', async () => {
-      mockFetch.mockResolvedValue(
-        jsonResponse({
-          data: [{ is_archived: 'not-a-boolean' }],
-          pagination: { total: 1, limit: 100, offset: 0 },
-        }),
-      );
+    it('should skip a malformed habit and record an error instead of throwing', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [{ is_archived: 'not-a-boolean' }],
+            pagination: { total: 1, limit: 100, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [],
+            pagination: { total: 0, limit: 100, offset: 0 },
+          }),
+        );
 
-      await expect(
-        getHabits('test-api-key', 'http://localhost:9999'),
-      ).rejects.toThrow();
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(result.habits).toEqual([]);
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('index 0');
+    });
+
+    it('should import remaining habits when only one is malformed, and record the error', async () => {
+      const badHabit = { ...sampleHabitV2, id: 'bad-1', name: undefined };
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [sampleHabitV2, badHabit],
+            pagination: { total: 2, limit: 100, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: [],
+            pagination: { total: 0, limit: 100, offset: 0 },
+          }),
+        );
+
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(result.habits).toHaveLength(1);
+      expect(result.habits[0].id).toBe('habit-1');
+      expect(result.errors).toHaveLength(1);
+      expect(result.errors[0]).toContain('habit "undefined"');
+    });
+
+    it('should treat a null data field as an empty page', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({ data: null, pagination: { total: 0, limit: 100, offset: 0 } }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({ data: null, pagination: { total: 0, limit: 100, offset: 0 } }),
+        );
+
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(result.habits).toEqual([]);
+      expect(result.errors).toEqual([]);
     });
   });
 
@@ -236,6 +301,86 @@ describe('Habitify API v2 client', () => {
         getStatistics('test-api-key', 'habit-1', undefined, undefined, 'http://localhost:9999'),
       ).rejects.toThrow();
     });
+
+    it('should merge dailyProgress across paginated statistics pages', async () => {
+      const page1 = {
+        ...sampleStats,
+        dailyProgress: [
+          { date: '2024-01-15', totalLog: 1, status: 'completed' },
+          { date: '2024-01-16', totalLog: 0, status: 'skipped' },
+        ],
+      };
+      const page2 = {
+        ...sampleStats,
+        dailyProgress: [{ date: '2024-01-17', totalLog: 1, status: 'completed' }],
+      };
+
+      mockFetch
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: page1,
+            pagination: { total: 3, limit: 2, offset: 0 },
+          }),
+        )
+        .mockResolvedValueOnce(
+          jsonResponse({
+            data: page2,
+            pagination: { total: 3, limit: 2, offset: 2 },
+          }),
+        );
+
+      const stats = await getStatistics(
+        'test-api-key',
+        'habit-1',
+        undefined,
+        undefined,
+        'http://localhost:9999',
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(stats.dailyProgress).toEqual([
+        { date: '2024-01-15', totalLog: 1, status: 'completed' },
+        { date: '2024-01-16', totalLog: 0, status: 'skipped' },
+        { date: '2024-01-17', totalLog: 1, status: 'completed' },
+      ]);
+
+      const secondUrl = (mockFetch.mock.calls[1] as [string])[0];
+      expect(secondUrl).toContain('offset=2');
+    });
+
+    it('should fetch only once when there is no pagination info', async () => {
+      mockFetch.mockResolvedValue(jsonResponse({ data: sampleStats }));
+
+      const stats = await getStatistics(
+        'test-api-key',
+        'habit-1',
+        undefined,
+        undefined,
+        'http://localhost:9999',
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+      expect(stats.dailyProgress).toHaveLength(2);
+    });
+
+    it('should fetch only once when pagination indicates a single complete page', async () => {
+      mockFetch.mockResolvedValue(
+        jsonResponse({
+          data: sampleStats,
+          pagination: { total: 2, limit: 100, offset: 0 },
+        }),
+      );
+
+      await getStatistics(
+        'test-api-key',
+        'habit-1',
+        undefined,
+        undefined,
+        'http://localhost:9999',
+      );
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('validate', () => {
@@ -259,6 +404,73 @@ describe('Habitify API v2 client', () => {
       await expect(
         validate('bad-key', 'http://localhost:9999'),
       ).rejects.toThrow();
+    });
+  });
+
+  describe('retry behavior (429/5xx)', () => {
+    const okHabitsPage = {
+      data: [],
+      pagination: { total: 0, limit: 100, offset: 0 },
+    };
+
+    it('should retry on 429 and succeed', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse('', 429))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage)); // archived page
+
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(result.habits).toEqual([]);
+      expect(result.errors).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should respect a Retry-After header when retrying', async () => {
+      const sleepSpy = jest.fn<(ms: number) => Promise<void>>(() => Promise.resolve());
+      __setRetrySleepForTesting(sleepSpy);
+
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse('', 429, { 'Retry-After': '2' }))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage));
+
+      await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(sleepSpy).toHaveBeenCalledWith(2000);
+    });
+
+    it('should retry on 5xx and succeed', async () => {
+      mockFetch
+        .mockResolvedValueOnce(jsonResponse('', 503))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage))
+        .mockResolvedValueOnce(jsonResponse(okHabitsPage));
+
+      const result = await getHabits('test-api-key', 'http://localhost:9999');
+
+      expect(result.habits).toEqual([]);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it('should throw once the retry limit is exceeded', async () => {
+      mockFetch.mockResolvedValue(jsonResponse('', 503));
+
+      await expect(
+        getHabits('test-api-key', 'http://localhost:9999'),
+      ).rejects.toThrow('get habits: status 503');
+
+      // initial attempt + 3 retries = 4 calls before giving up
+      expect(mockFetch).toHaveBeenCalledTimes(4);
+    });
+
+    it('should not retry non-retryable 4xx errors', async () => {
+      mockFetch.mockResolvedValue(jsonResponse('', 400));
+
+      await expect(
+        getHabits('test-api-key', 'http://localhost:9999'),
+      ).rejects.toThrow('get habits: status 400');
+
+      expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/lib/habitify/__tests__/import-service.test.ts
+++ b/src/lib/habitify/__tests__/import-service.test.ts
@@ -3,38 +3,57 @@ import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 // ─── Mocks ────────────────────────────────────────────
 
 const mockGetHabits = jest.fn<(...args: unknown[]) => Promise<unknown>>();
-const mockGetLogs = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetStatistics = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockFormatDate = jest.fn<(...args: unknown[]) => string>();
 
 jest.mock('../client', () => ({
   getHabits: (...args: unknown[]) => mockGetHabits(...args),
-  getLogs: (...args: unknown[]) => mockGetLogs(...args),
+  getStatistics: (...args: unknown[]) => mockGetStatistics(...args),
+  formatDate: (...args: unknown[]) => mockFormatDate(...args),
 }));
 
 import { runImport, type ImportParams } from '../import-service';
-import type { HabitifyHabit, HabitifyLog } from '../types';
+import type { HabitifyHabit, HabitifyStatistics } from '../types';
 
 // ─── Test data ────────────────────────────────────────
 
-const sampleHabit: HabitifyHabit = {
+const sampleHabitV2: HabitifyHabit = {
   id: 'h-1',
   name: 'Morning Run',
-  is_archived: false,
-  start_date: '2024-01-01T00:00:00+00:00',
-  time_of_day: ['morning'],
-  area: { id: 'area-1', name: 'Health' },
-  recurrence: 'RRULE:FREQ=DAILY',
-  goal: { unit_type: 'count', value: 1, periodicity: 'daily' },
-  log_method: 'check',
-  priority: 1,
-  created_date: '2024-01-01T00:00:00+00:00',
+  occurrence: { type: 'daily' },
+  startDate: '2024-01-01',
+  createdAt: '2024-01-01T00:00:00Z',
+  isArchived: false,
+  logMethod: 'manual',
+  goals: [
+    {
+      id: 'goal-1',
+      createdAt: '2024-01-01T00:00:00Z',
+      periodicity: 'daily',
+      value: 1,
+      unit: 'rep',
+      isActive: true,
+    },
+  ],
+  areas: [{ id: 'area-1', name: 'Health' }],
+  timeOfDays: [{ id: 'tod-1', name: 'Morning' }],
 };
 
-const sampleLog: HabitifyLog = {
-  id: 'log-1',
-  habit_id: 'h-1',
-  value: 1,
-  created_date: '2024-01-15T10:30:00+00:00',
-  unit_type: 'count',
+const sampleStatistics: HabitifyStatistics = {
+  id: 'h-1',
+  name: 'Morning Run',
+  type: 'good',
+  totalLogs: 2,
+  skips: 0,
+  fails: 0,
+  completions: 2,
+  unit: { id: 'u-1', name: 'Repetition', symbol: 'rep' },
+  periodicity: 'daily',
+  avg: 1,
+  dailyProgress: [
+    { date: '2024-01-15', totalLog: 1, status: 'completed' },
+    { date: '2024-01-16', totalLog: 1, status: 'completed' },
+  ],
 };
 
 // ─── Tests ────────────────────────────────────────────
@@ -42,10 +61,11 @@ const sampleLog: HabitifyLog = {
 describe('runImport', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockFormatDate.mockReturnValue('2024-01-31');
   });
 
   it('should return empty result when both flags are false', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
 
     const mockFrom = jest.fn();
     const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
@@ -83,7 +103,7 @@ describe('runImport', () => {
   });
 
   it('should batch upsert habits with categories', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -136,20 +156,23 @@ describe('runImport', () => {
 
     // Verify batch habit upsert
     expect(mockUpsertHabit).toHaveBeenCalledWith(
-      [expect.objectContaining({
-        user_id: 'user-1',
-        name: 'Morning Run',
-        external_id: 'h-1',
-        external_source: 'habitify',
-        category_id: 'cat-uuid-1',
-      })],
+      [
+        expect.objectContaining({
+          user_id: 'user-1',
+          name: 'Morning Run',
+          external_id: 'h-1',
+          external_source: 'habitify',
+          category_id: 'cat-uuid-1',
+          recurrence_rule: 'RRULE:FREQ=DAILY',
+        }),
+      ],
       { onConflict: 'user_id,external_id' },
     );
   });
 
-  it('should batch upsert logs', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
-    mockGetLogs.mockResolvedValue([sampleLog]);
+  it('should batch upsert logs from statistics dailyProgress', async () => {
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetStatistics.mockResolvedValue(sampleStatistics);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -199,27 +222,97 @@ describe('runImport', () => {
     });
 
     expect(result.habits_imported).toBe(1);
-    expect(result.logs_imported).toBe(1);
+    expect(result.logs_imported).toBe(2);
     expect(result.errors).toEqual([]);
 
-    // Verify batch log upsert (array)
+    // Verify logs were created from dailyProgress
     expect(mockUpsertLog).toHaveBeenCalledWith(
-      [expect.objectContaining({
-        user_id: 'user-1',
-        habit_id: 'habity-h-1',
-        value: 1,
-        target_date: '2024-01-15',
-        status: 'completed',
-        external_id: 'log-1',
-      })],
+      [
+        expect.objectContaining({
+          user_id: 'user-1',
+          habit_id: 'habity-h-1',
+          value: 1,
+          target_date: '2024-01-15',
+          status: 'completed',
+          external_id: null,
+        }),
+        expect.objectContaining({
+          target_date: '2024-01-16',
+        }),
+      ],
       { onConflict: 'habit_id,target_date', ignoreDuplicates: true },
     );
   });
 
-  it('should handle habit without area (no category)', async () => {
+  it('should skip failed and inprogress entries from dailyProgress', async () => {
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetStatistics.mockResolvedValue({
+      ...sampleStatistics,
+      dailyProgress: [
+        { date: '2024-01-15', totalLog: 1, status: 'completed' },
+        { date: '2024-01-16', totalLog: 0, status: 'failed' },
+        { date: '2024-01-17', totalLog: 0, status: 'inprogress' },
+        { date: '2024-01-18', totalLog: 0, status: 'skipped' },
+      ],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'cat-uuid-1', name: 'Health' }],
+        error: null,
+      }),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertHabit = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'habity-h-1', external_id: 'h-1' }],
+        error: null,
+      }),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertLog = jest.fn<(...args: any[]) => any>().mockResolvedValue({
+      error: null,
+    });
+
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
+      if (table === 'habit_logs') return { upsert: mockUpsertLog };
+      return {};
+    });
+
+    const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
+
+    const result = await runImport({
+      apiKey: 'test-key',
+      importHabits: true,
+      importLogs: true,
+      timezone: 'UTC',
+      userId: 'user-1',
+      supabase,
+    });
+
+    // Only completed + skipped = 2 logs
+    expect(result.logs_imported).toBe(2);
+
+    expect(mockUpsertLog).toHaveBeenCalledWith(
+      [
+        expect.objectContaining({ target_date: '2024-01-15', status: 'completed' }),
+        expect.objectContaining({ target_date: '2024-01-18', status: 'skipped' }),
+      ],
+      expect.anything(),
+    );
+  });
+
+  it('should handle habit without areas (no category)', async () => {
     const habitNoArea: HabitifyHabit = {
-      ...sampleHabit,
-      area: null,
+      ...sampleHabitV2,
+      areas: [],
     };
     mockGetHabits.mockResolvedValue([habitNoArea]);
 
@@ -256,7 +349,7 @@ describe('runImport', () => {
   });
 
   it('should report batch habit upsert errors', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -277,12 +370,8 @@ describe('runImport', () => {
     });
 
     const mockFrom = jest.fn((table: string) => {
-      if (table === 'categories') {
-        return { upsert: mockUpsertCategory };
-      }
-      if (table === 'habits') {
-        return { upsert: mockUpsertHabit };
-      }
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
       return {};
     });
 
@@ -302,9 +391,9 @@ describe('runImport', () => {
     expect(result.errors[0]).toContain('DB error');
   });
 
-  it('should continue on log fetch errors', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
-    mockGetLogs.mockRejectedValue(new Error('API timeout'));
+  it('should continue on statistics fetch errors', async () => {
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetStatistics.mockRejectedValue(new Error('API timeout'));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -325,12 +414,8 @@ describe('runImport', () => {
     });
 
     const mockFrom = jest.fn((table: string) => {
-      if (table === 'categories') {
-        return { upsert: mockUpsertCategory };
-      }
-      if (table === 'habits') {
-        return { upsert: mockUpsertHabit };
-      }
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
       return {};
     });
 
@@ -353,8 +438,8 @@ describe('runImport', () => {
   });
 
   it('should build habit ID map from existing habits when not importing habits', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabit]);
-    mockGetLogs.mockResolvedValue([sampleLog]);
+    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetStatistics.mockResolvedValue(sampleStatistics);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -382,15 +467,9 @@ describe('runImport', () => {
     });
 
     const mockFrom = jest.fn((table: string) => {
-      if (table === 'categories') {
-        return { upsert: mockUpsertCategory };
-      }
-      if (table === 'habits') {
-        return { select: mockSelectFind };
-      }
-      if (table === 'habit_logs') {
-        return { upsert: mockUpsertLog };
-      }
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { select: mockSelectFind };
+      if (table === 'habit_logs') return { upsert: mockUpsertLog };
       return {};
     });
 
@@ -406,11 +485,13 @@ describe('runImport', () => {
     });
 
     expect(result.habits_imported).toBe(0);
-    expect(result.logs_imported).toBe(1);
+    expect(result.logs_imported).toBe(2);
 
-    // Verify log was linked to existing habit
+    // Verify logs were linked to existing habit
     expect(mockUpsertLog).toHaveBeenCalledWith(
-      [expect.objectContaining({ habit_id: 'existing-h-1' })],
+      expect.arrayContaining([
+        expect.objectContaining({ habit_id: 'existing-h-1' }),
+      ]),
       expect.anything(),
     );
   });

--- a/src/lib/habitify/__tests__/import-service.test.ts
+++ b/src/lib/habitify/__tests__/import-service.test.ts
@@ -65,7 +65,7 @@ describe('runImport', () => {
   });
 
   it('should return empty result when both flags are false', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
 
     const mockFrom = jest.fn();
     const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
@@ -74,7 +74,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: false,
       importLogs: false,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -84,26 +83,118 @@ describe('runImport', () => {
     expect(result.errors).toEqual([]);
   });
 
-  it('should throw when API key is invalid', async () => {
+  it('should return an errors-populated result (not throw) when the API key is invalid', async () => {
     mockGetHabits.mockRejectedValue(new Error('get habits: status 401'));
 
     const mockFrom = jest.fn();
     const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
 
-    await expect(
-      runImport({
-        apiKey: 'bad-key',
-        importHabits: true,
-        importLogs: true,
-        timezone: 'UTC',
-        userId: 'user-1',
-        supabase,
+    const result = await runImport({
+      apiKey: 'bad-key',
+      importHabits: true,
+      importLogs: true,
+      userId: 'user-1',
+      supabase,
+    });
+
+    expect(result.habits_imported).toBe(0);
+    expect(result.logs_imported).toBe(0);
+    expect(result.errors).toHaveLength(1);
+    expect(result.errors[0]).toContain('get habits: status 401');
+    // Should not touch the DB at all when habits can't be fetched.
+    expect(mockFrom).not.toHaveBeenCalled();
+  });
+
+  it('should surface fetch-level errors from getHabits alongside successfully parsed habits', async () => {
+    mockGetHabits.mockResolvedValue({
+      habits: [sampleHabitV2],
+      errors: ['habit "Bad Habit": Required'],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'cat-uuid-1', name: 'Health' }],
+        error: null,
       }),
-    ).rejects.toThrow('get habits: status 401');
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertHabit = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'habity-h-1', external_id: 'h-1' }],
+        error: null,
+      }),
+    });
+
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
+      return {};
+    });
+
+    const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
+
+    const result = await runImport({
+      apiKey: 'test-key',
+      importHabits: true,
+      importLogs: false,
+      userId: 'user-1',
+      supabase,
+    });
+
+    expect(result.habits_imported).toBe(1);
+    expect(result.errors).toContain('habit "Bad Habit": Required');
+  });
+
+  it('should not throw and should record an error when ensureCategories fails', async () => {
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: null,
+        error: { message: 'categories DB error' },
+      }),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertHabit = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'habity-h-1', external_id: 'h-1' }],
+        error: null,
+      }),
+    });
+
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
+      return {};
+    });
+
+    const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
+
+    const result = await runImport({
+      apiKey: 'test-key',
+      importHabits: true,
+      importLogs: false,
+      userId: 'user-1',
+      supabase,
+    });
+
+    // Habit import still proceeds (without category) despite categories failing.
+    expect(result.habits_imported).toBe(1);
+    expect(result.errors).toEqual(
+      expect.arrayContaining([expect.stringContaining('categories DB error')]),
+    );
   });
 
   it('should batch upsert habits with categories', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -139,7 +230,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: false,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -171,7 +261,7 @@ describe('runImport', () => {
   });
 
   it('should batch upsert logs from statistics dailyProgress', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
     mockGetStatistics.mockResolvedValue(sampleStatistics);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -216,7 +306,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: true,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -245,7 +334,7 @@ describe('runImport', () => {
   });
 
   it('should skip failed and inprogress entries from dailyProgress', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
     mockGetStatistics.mockResolvedValue({
       ...sampleStatistics,
       dailyProgress: [
@@ -292,7 +381,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: true,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -314,7 +402,7 @@ describe('runImport', () => {
       ...sampleHabitV2,
       areas: [],
     };
-    mockGetHabits.mockResolvedValue([habitNoArea]);
+    mockGetHabits.mockResolvedValue({ habits: [habitNoArea], errors: [] });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertHabit = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -338,7 +426,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: false,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -349,7 +436,7 @@ describe('runImport', () => {
   });
 
   it('should report batch habit upsert errors', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
@@ -381,7 +468,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: false,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -392,7 +478,7 @@ describe('runImport', () => {
   });
 
   it('should continue on statistics fetch errors', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
     mockGetStatistics.mockRejectedValue(new Error('API timeout'));
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -425,7 +511,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: true,
       importLogs: true,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -438,7 +523,7 @@ describe('runImport', () => {
   });
 
   it('should build habit ID map from existing habits when not importing habits', async () => {
-    mockGetHabits.mockResolvedValue([sampleHabitV2]);
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
     mockGetStatistics.mockResolvedValue(sampleStatistics);
 
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -479,7 +564,6 @@ describe('runImport', () => {
       apiKey: 'test-key',
       importHabits: false,
       importLogs: true,
-      timezone: 'UTC',
       userId: 'user-1',
       supabase,
     });
@@ -494,5 +578,83 @@ describe('runImport', () => {
       ]),
       expect.anything(),
     );
+  });
+
+  it('should import zero logs without errors when dailyProgress is empty', async () => {
+    mockGetHabits.mockResolvedValue({ habits: [sampleHabitV2], errors: [] });
+    mockGetStatistics.mockResolvedValue({
+      ...sampleStatistics,
+      totalLogs: 0,
+      completions: 0,
+      dailyProgress: [],
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertCategory = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'cat-uuid-1', name: 'Health' }],
+        error: null,
+      }),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertHabit = jest.fn<(...args: any[]) => any>().mockReturnValue({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      select: jest.fn<any>().mockResolvedValue({
+        data: [{ id: 'habity-h-1', external_id: 'h-1' }],
+        error: null,
+      }),
+    });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const mockUpsertLog = jest.fn<(...args: any[]) => any>().mockResolvedValue({
+      error: null,
+    });
+
+    const mockFrom = jest.fn((table: string) => {
+      if (table === 'categories') return { upsert: mockUpsertCategory };
+      if (table === 'habits') return { upsert: mockUpsertHabit };
+      if (table === 'habit_logs') return { upsert: mockUpsertLog };
+      return {};
+    });
+
+    const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
+
+    const result = await runImport({
+      apiKey: 'test-key',
+      importHabits: true,
+      importLogs: true,
+      userId: 'user-1',
+      supabase,
+    });
+
+    expect(result.habits_imported).toBe(1);
+    expect(result.logs_imported).toBe(0);
+    expect(result.errors).toEqual([]);
+    // No log upsert should happen when there are no rows.
+    expect(mockUpsertLog).not.toHaveBeenCalled();
+  });
+
+  it('should complete without errors or DB writes when there are no habits at all', async () => {
+    mockGetHabits.mockResolvedValue({ habits: [], errors: [] });
+
+    const mockFrom = jest.fn();
+    const supabase = { from: mockFrom } as unknown as ImportParams['supabase'];
+
+    const result = await runImport({
+      apiKey: 'test-key',
+      importHabits: true,
+      importLogs: true,
+      userId: 'user-1',
+      supabase,
+    });
+
+    expect(result.habits_imported).toBe(0);
+    expect(result.logs_imported).toBe(0);
+    expect(result.errors).toEqual([]);
+    expect(mockGetStatistics).not.toHaveBeenCalled();
+    // No categories/habits/logs writes for an account with zero habits.
+    expect(mockFrom).not.toHaveBeenCalled();
   });
 });

--- a/src/lib/habitify/__tests__/transform.test.ts
+++ b/src/lib/habitify/__tests__/transform.test.ts
@@ -62,7 +62,8 @@ describe('transformHabit', () => {
 
     expect(result.user_id).toBe('user-1');
     expect(result.name).toBe('Morning Run');
-    expect(result.tracking_type).toBe('numeric');
+    // Default goal is 1 rep — Habitify's checkbox-style habit shape.
+    expect(result.tracking_type).toBe('boolean');
     expect(result.goal_value).toBe(1);
     expect(result.goal_unit).toBe('times');
     expect(result.goal_period).toBe('daily');
@@ -120,6 +121,15 @@ describe('transformHabit', () => {
     expect(result.goal_value).toBe(30);
   });
 
+  it('should use numeric tracking_type for a rep goal with value > 1', () => {
+    const h = makeHabit({
+      goals: [makeGoal({ unit: 'rep', value: 5 })],
+    });
+    const result = transformHabit(h, 'user-1', {});
+    expect(result.tracking_type).toBe('numeric');
+    expect(result.goal_value).toBe(5);
+  });
+
   it('should convert weekDays occurrence to RRULE', () => {
     const h = makeHabit({
       occurrence: { type: 'weekDays', days: [1, 3, 5] },
@@ -140,6 +150,19 @@ describe('transformHabit', () => {
     const h = makeHabit({ description: 'Run every morning' });
     const result = transformHabit(h, 'user-1', {});
     expect(result.description).toBe('Run every morning');
+  });
+
+  it('should import the habit with null goal fields when periodicity is unmappable', () => {
+    const h = makeHabit({
+      goals: [makeGoal({ periodicity: 'yearly', value: 5, unit: 'kM' })],
+    });
+    const result = transformHabit(h, 'user-1', {});
+    expect(result.goal_value).toBeNull();
+    expect(result.goal_unit).toBeNull();
+    expect(result.goal_period).toBeNull();
+    // The habit itself is still imported.
+    expect(result.name).toBe('Morning Run');
+    expect(result.external_id).toBe('h-1');
   });
 });
 
@@ -228,17 +251,28 @@ describe('findActiveGoal', () => {
 
 describe('inferTrackingType', () => {
   it.each([
-    { unit: 'min', expected: 'duration' },
-    { unit: 'hr', expected: 'duration' },
-    { unit: 'sec', expected: 'duration' },
-    { unit: 'ms', expected: 'duration' },
-    { unit: 'rep', expected: 'numeric' },
-    { unit: 'step', expected: 'numeric' },
-    { unit: 'kM', expected: 'numeric' },
-    { unit: 'm', expected: 'numeric' },
-  ])('should infer "$expected" for unit "$unit"', ({ unit, expected }) => {
-    expect(inferTrackingType(makeGoal({ unit }))).toBe(expected);
-  });
+    // Duration units always map to 'duration', regardless of goal value.
+    { unit: 'min', value: 1, expected: 'duration' },
+    { unit: 'min', value: 30, expected: 'duration' },
+    { unit: 'hr', value: 1, expected: 'duration' },
+    { unit: 'sec', value: 1, expected: 'duration' },
+    { unit: 'ms', value: 1, expected: 'duration' },
+    // 'rep' + value 1 is Habitify's checkbox ("just do it") shape → boolean.
+    { unit: 'rep', value: 1, expected: 'boolean' },
+    // 'rep' with any other value is a real numeric goal (e.g. "5 reps").
+    { unit: 'rep', value: 2, expected: 'numeric' },
+    { unit: 'rep', value: 5, expected: 'numeric' },
+    // Non-'rep' units are never treated as boolean, even at value 1.
+    { unit: 'step', value: 1, expected: 'numeric' },
+    { unit: 'step', value: 100, expected: 'numeric' },
+    { unit: 'kM', value: 1, expected: 'numeric' },
+    { unit: 'm', value: 1, expected: 'numeric' },
+  ])(
+    'should infer "$expected" for unit "$unit" and value $value',
+    ({ unit, value, expected }) => {
+      expect(inferTrackingType(makeGoal({ unit, value }))).toBe(expected);
+    },
+  );
 
   it('should return boolean when goal is null', () => {
     expect(inferTrackingType(null)).toBe('boolean');
@@ -256,6 +290,11 @@ describe('mapGoal', () => {
   it('should map a v2 goal', () => {
     const result = mapGoal(makeGoal({ value: 5, unit: 'kM', periodicity: 'weekly' }));
     expect(result).toEqual({ value: 5, unit: 'km', period: 'weekly' });
+  });
+
+  it('should not adopt the goal (null value/unit/period) when periodicity is unknown', () => {
+    const result = mapGoal(makeGoal({ value: 5, unit: 'kM', periodicity: 'yearly' }));
+    expect(result).toEqual({ value: null, unit: null, period: null });
   });
 });
 
@@ -288,11 +327,16 @@ describe('mapGoalPeriod', () => {
     ['daily', 'daily'],
     ['weekly', 'weekly'],
     ['monthly', 'monthly'],
-    ['yearly', 'daily'],
-    ['unknown', 'daily'],
   ])('should map "%s" to "%s"', (input, expected) => {
     expect(mapGoalPeriod(input)).toBe(expected);
   });
+
+  it.each(['yearly', 'unknown'])(
+    'should return null for unmappable periodicity "%s" instead of fabricating "daily"',
+    (input) => {
+      expect(mapGoalPeriod(input)).toBeNull();
+    },
+  );
 });
 
 // ─── occurrenceToRRule ────────────────────────────────
@@ -324,6 +368,16 @@ describe('occurrenceToRRule', () => {
     expect(
       occurrenceToRRule({ type: 'weekDays', days: [0, 1, 2, 3, 4, 5, 6] }),
     ).toBe('RRULE:FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA');
+  });
+
+  it('should fall back to RRULE:FREQ=DAILY when weekDays.days has only out-of-range values', () => {
+    expect(occurrenceToRRule({ type: 'weekDays', days: [7, -1] })).toBe(
+      'RRULE:FREQ=DAILY',
+    );
+  });
+
+  it('should return null for an unknown occurrence type', () => {
+    expect(occurrenceToRRule({ type: 'timesPerWeek', times: 3 })).toBeNull();
   });
 });
 

--- a/src/lib/habitify/__tests__/transform.test.ts
+++ b/src/lib/habitify/__tests__/transform.test.ts
@@ -2,40 +2,67 @@ import { describe, expect, it } from '@jest/globals';
 
 import {
   transformHabit,
-  transformLog,
-  mapLogMethod,
+  transformDailyProgress,
+  findActiveGoal,
+  inferTrackingType,
   mapGoal,
   mapGoalUnit,
   mapGoalPeriod,
-  mapTimeOfDay,
-  safePriorityToInt,
+  occurrenceToRRule,
+  mapTimeOfDays,
 } from '../transform';
-import type { HabitifyHabit, HabitifyLog } from '../types';
+import type { HabitifyHabit, HabitifyGoal, HabitifyDailyProgress } from '../types';
+
+// ─── Helper: minimal v2 habit ─────────────────────────
+
+function makeHabit(overrides: Partial<HabitifyHabit> = {}): HabitifyHabit {
+  return {
+    id: 'h-1',
+    name: 'Morning Run',
+    occurrence: { type: 'daily' },
+    startDate: '2024-01-01',
+    createdAt: '2024-01-01T00:00:00Z',
+    isArchived: false,
+    logMethod: 'manual',
+    goals: [
+      {
+        id: 'goal-1',
+        createdAt: '2024-01-01T00:00:00Z',
+        periodicity: 'daily',
+        value: 1,
+        unit: 'rep',
+        isActive: true,
+      },
+    ],
+    areas: [{ id: 'area-1', name: 'Health' }],
+    timeOfDays: [{ id: 'tod-1', name: 'Morning' }],
+    ...overrides,
+  };
+}
+
+function makeGoal(overrides: Partial<HabitifyGoal> = {}): HabitifyGoal {
+  return {
+    id: 'goal-1',
+    createdAt: '2024-01-01T00:00:00Z',
+    periodicity: 'daily',
+    value: 1,
+    unit: 'rep',
+    isActive: true,
+    ...overrides,
+  };
+}
 
 // ─── transformHabit ───────────────────────────────────
 
 describe('transformHabit', () => {
-  it('should transform a basic check habit', () => {
-    const h: HabitifyHabit = {
-      id: 'h-1',
-      name: 'Morning Run',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: ['morning'],
-      log_method: 'check',
-      priority: 2,
-      recurrence: 'RRULE:FREQ=DAILY',
-      goal: { unit_type: 'count', value: 1, periodicity: 'daily' },
-      area: { id: 'area-1', name: 'Health' },
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
-
+  it('should transform a basic v2 habit', () => {
+    const h = makeHabit();
     const categoryMap = { 'area-1': 'cat-uuid-1' };
     const result = transformHabit(h, 'user-1', categoryMap);
 
     expect(result.user_id).toBe('user-1');
     expect(result.name).toBe('Morning Run');
-    expect(result.tracking_type).toBe('boolean');
+    expect(result.tracking_type).toBe('numeric');
     expect(result.goal_value).toBe(1);
     expect(result.goal_unit).toBe('times');
     expect(result.goal_period).toBe('daily');
@@ -47,163 +74,188 @@ describe('transformHabit', () => {
     expect(result.recurrence_rule).toBe('RRULE:FREQ=DAILY');
     expect(result.time_of_day).toEqual(['morning']);
     expect(result.end_date).toBeNull();
-    expect(result.sort_order).toBe(2);
   });
 
-  it('should set status to archived when is_archived is true', () => {
-    const h: HabitifyHabit = {
-      id: 'h-2',
-      name: 'Old Habit',
-      is_archived: true,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: [],
-      log_method: 'check',
-      priority: 0,
-      recurrence: '',
-      goal: null,
-      area: null,
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
-
-    const result = transformHabit(h, 'user-1', {});
+  it('should set status to archived when isArchived is true', () => {
+    const result = transformHabit(makeHabit({ isArchived: true }), 'user-1', {});
     expect(result.status).toBe('archived');
   });
 
-  it('should set category_id to null when area is null', () => {
-    const h: HabitifyHabit = {
-      id: 'h-1',
-      name: 'Test',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: [],
-      log_method: 'check',
-      priority: 0,
-      recurrence: '',
-      goal: null,
-      area: null,
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
-
-    const result = transformHabit(h, 'user-1', {});
+  it('should set category_id to null when areas is empty', () => {
+    const result = transformHabit(makeHabit({ areas: [] }), 'user-1', {});
     expect(result.category_id).toBeNull();
   });
 
-  it('should default time_of_day to ["anytime"] when empty', () => {
-    const h: HabitifyHabit = {
-      id: 'h-1',
-      name: 'Test',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: [],
-      log_method: 'check',
-      priority: 0,
-      recurrence: '',
-      goal: null,
-      area: null,
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
+  it('should use first area for category mapping', () => {
+    const h = makeHabit({
+      areas: [
+        { id: 'area-1', name: 'Health' },
+        { id: 'area-2', name: 'Work' },
+      ],
+    });
+    const categoryMap = { 'area-1': 'cat-1', 'area-2': 'cat-2' };
+    const result = transformHabit(h, 'user-1', categoryMap);
+    expect(result.category_id).toBe('cat-1');
+  });
 
-    const result = transformHabit(h, 'user-1', {});
+  it('should default time_of_day to ["anytime"] when timeOfDays is empty', () => {
+    const result = transformHabit(makeHabit({ timeOfDays: [] }), 'user-1', {});
     expect(result.time_of_day).toEqual(['anytime']);
   });
 
-  it('should filter invalid time_of_day values', () => {
-    const h: HabitifyHabit = {
-      id: 'h-1',
-      name: 'Test',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: ['morning', 'invalid_value', 'evening'],
-      log_method: 'check',
-      priority: 0,
-      recurrence: '',
-      goal: null,
-      area: null,
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
-
-    const result = transformHabit(h, 'user-1', {});
-    expect(result.time_of_day).toEqual(['morning', 'evening']);
+  it('should use boolean tracking_type when no goals', () => {
+    const result = transformHabit(makeHabit({ goals: [] }), 'user-1', {});
+    expect(result.tracking_type).toBe('boolean');
+    expect(result.goal_value).toBe(1);
+    expect(result.goal_unit).toBe('times');
   });
 
-  it('should set recurrence_rule to null for empty recurrence', () => {
-    const h: HabitifyHabit = {
-      id: 'h-1',
-      name: 'Test',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: [],
-      log_method: 'check',
-      priority: 0,
-      recurrence: '',
-      goal: null,
-      area: null,
-      created_date: '2024-01-01T00:00:00+00:00',
-    };
-
+  it('should use duration tracking_type for time-based goals', () => {
+    const h = makeHabit({
+      goals: [makeGoal({ unit: 'min', value: 30 })],
+    });
     const result = transformHabit(h, 'user-1', {});
-    expect(result.recurrence_rule).toBeNull();
+    expect(result.tracking_type).toBe('duration');
+    expect(result.goal_unit).toBe('min');
+    expect(result.goal_value).toBe(30);
+  });
+
+  it('should convert weekDays occurrence to RRULE', () => {
+    const h = makeHabit({
+      occurrence: { type: 'weekDays', days: [1, 3, 5] },
+    });
+    const result = transformHabit(h, 'user-1', {});
+    expect(result.recurrence_rule).toBe('RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR');
+  });
+
+  it('should convert intervalDays occurrence to RRULE', () => {
+    const h = makeHabit({
+      occurrence: { type: 'intervalDays', interval: 3 },
+    });
+    const result = transformHabit(h, 'user-1', {});
+    expect(result.recurrence_rule).toBe('RRULE:FREQ=DAILY;INTERVAL=3');
+  });
+
+  it('should use description from v2 habit', () => {
+    const h = makeHabit({ description: 'Run every morning' });
+    const result = transformHabit(h, 'user-1', {});
+    expect(result.description).toBe('Run every morning');
   });
 });
 
-// ─── mapLogMethod ─────────────────────────────────────
+// ─── transformDailyProgress ───────────────────────────
 
-describe('mapLogMethod', () => {
+describe('transformDailyProgress', () => {
+  it('should transform a completed daily progress', () => {
+    const dp: HabitifyDailyProgress = {
+      date: '2024-01-15',
+      totalLog: 3.5,
+      status: 'completed',
+    };
+
+    const result = transformDailyProgress(dp, 'habity-h-1', 'user-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.user_id).toBe('user-1');
+    expect(result!.habit_id).toBe('habity-h-1');
+    expect(result!.value).toBe(3.5);
+    expect(result!.target_date).toBe('2024-01-15');
+    expect(result!.completed_at).toBe('2024-01-15T00:00:00');
+    expect(result!.status).toBe('completed');
+    expect(result!.external_id).toBeNull();
+  });
+
+  it('should transform a skipped daily progress', () => {
+    const dp: HabitifyDailyProgress = {
+      date: '2024-01-16',
+      totalLog: 0,
+      status: 'skipped',
+    };
+
+    const result = transformDailyProgress(dp, 'habity-h-1', 'user-1');
+
+    expect(result).not.toBeNull();
+    expect(result!.status).toBe('skipped');
+    expect(result!.value).toBe(0);
+  });
+
+  it('should return null for failed status', () => {
+    const dp: HabitifyDailyProgress = {
+      date: '2024-01-17',
+      totalLog: 0,
+      status: 'failed',
+    };
+
+    expect(transformDailyProgress(dp, 'habity-h-1', 'user-1')).toBeNull();
+  });
+
+  it('should return null for inprogress status', () => {
+    const dp: HabitifyDailyProgress = {
+      date: '2024-01-18',
+      totalLog: 2,
+      status: 'inprogress',
+    };
+
+    expect(transformDailyProgress(dp, 'habity-h-1', 'user-1')).toBeNull();
+  });
+});
+
+// ─── findActiveGoal ───────────────────────────────────
+
+describe('findActiveGoal', () => {
+  it('should return the active goal', () => {
+    const goals = [
+      makeGoal({ id: 'g1', isActive: false }),
+      makeGoal({ id: 'g2', isActive: true }),
+    ];
+    expect(findActiveGoal(goals)!.id).toBe('g2');
+  });
+
+  it('should fall back to first goal when none active', () => {
+    const goals = [
+      makeGoal({ id: 'g1', isActive: false }),
+      makeGoal({ id: 'g2', isActive: false }),
+    ];
+    expect(findActiveGoal(goals)!.id).toBe('g1');
+  });
+
+  it('should return null for empty goals', () => {
+    expect(findActiveGoal([])).toBeNull();
+  });
+});
+
+// ─── inferTrackingType ────────────────────────────────
+
+describe('inferTrackingType', () => {
   it.each([
-    ['check', 'boolean'],
-    ['measure', 'numeric'],
-    ['number', 'numeric'],
-    ['timer', 'duration'],
-    ['unknown', 'boolean'],
-  ])('should map "%s" to "%s"', (input, expected) => {
-    expect(mapLogMethod(input)).toBe(expected);
+    { unit: 'min', expected: 'duration' },
+    { unit: 'hr', expected: 'duration' },
+    { unit: 'sec', expected: 'duration' },
+    { unit: 'ms', expected: 'duration' },
+    { unit: 'rep', expected: 'numeric' },
+    { unit: 'step', expected: 'numeric' },
+    { unit: 'kM', expected: 'numeric' },
+    { unit: 'm', expected: 'numeric' },
+  ])('should infer "$expected" for unit "$unit"', ({ unit, expected }) => {
+    expect(inferTrackingType(makeGoal({ unit }))).toBe(expected);
+  });
+
+  it('should return boolean when goal is null', () => {
+    expect(inferTrackingType(null)).toBe('boolean');
   });
 });
 
 // ─── mapGoal ──────────────────────────────────────────
 
 describe('mapGoal', () => {
-  it.each([
-    {
-      name: 'nil goal defaults',
-      goal: null,
-      wantValue: 1,
-      wantUnit: 'times',
-      wantPeriod: 'daily',
-    },
-    {
-      name: 'count daily',
-      goal: { unit_type: 'count', value: 5, periodicity: 'daily' },
-      wantValue: 5,
-      wantUnit: 'times',
-      wantPeriod: 'daily',
-    },
-    {
-      name: 'minute weekly',
-      goal: { unit_type: 'minute', value: 30, periodicity: 'weekly' },
-      wantValue: 30,
-      wantUnit: 'min',
-      wantPeriod: 'weekly',
-    },
-    {
-      name: 'kilometer monthly',
-      goal: { unit_type: 'kilometer', value: 100, periodicity: 'monthly' },
-      wantValue: 100,
-      wantUnit: 'km',
-      wantPeriod: 'monthly',
-    },
-    {
-      name: 'unknown unit type passes through',
-      goal: { unit_type: 'custom_unit', value: 10, periodicity: 'daily' },
-      wantValue: 10,
-      wantUnit: 'custom_unit',
-      wantPeriod: 'daily',
-    },
-  ])('$name', ({ goal, wantValue, wantUnit, wantPeriod }) => {
-    const result = mapGoal(goal);
-    expect(result.value).toBe(wantValue);
-    expect(result.unit).toBe(wantUnit);
-    expect(result.period).toBe(wantPeriod);
+  it('should return defaults for null goal', () => {
+    const result = mapGoal(null);
+    expect(result).toEqual({ value: 1, unit: 'times', period: 'daily' });
+  });
+
+  it('should map a v2 goal', () => {
+    const result = mapGoal(makeGoal({ value: 5, unit: 'kM', periodicity: 'weekly' }));
+    expect(result).toEqual({ value: 5, unit: 'km', period: 'weekly' });
   });
 });
 
@@ -211,12 +263,19 @@ describe('mapGoal', () => {
 
 describe('mapGoalUnit', () => {
   it.each([
-    ['count', 'times'],
-    ['minute', 'min'],
-    ['hour', 'hours'],
-    ['meter', 'm'],
-    ['kilometer', 'km'],
-    ['custom_unit', 'custom_unit'],
+    ['rep', 'times'],
+    ['min', 'min'],
+    ['hr', 'hours'],
+    ['sec', 'sec'],
+    ['kM', 'km'],
+    ['m', 'm'],
+    ['step', 'steps'],
+    ['floor', 'floors'],
+    ['kCal', 'kcal'],
+    ['L', 'L'],
+    ['mL', 'mL'],
+    ['kg', 'kg'],
+    ['unknown_unit', 'unknown_unit'],
   ])('should map "%s" to "%s"', (input, expected) => {
     expect(mapGoalUnit(input)).toBe(expected);
   });
@@ -229,117 +288,74 @@ describe('mapGoalPeriod', () => {
     ['daily', 'daily'],
     ['weekly', 'weekly'],
     ['monthly', 'monthly'],
+    ['yearly', 'daily'],
     ['unknown', 'daily'],
   ])('should map "%s" to "%s"', (input, expected) => {
     expect(mapGoalPeriod(input)).toBe(expected);
   });
 });
 
-// ─── mapTimeOfDay ─────────────────────────────────────
+// ─── occurrenceToRRule ────────────────────────────────
 
-describe('mapTimeOfDay', () => {
+describe('occurrenceToRRule', () => {
+  it('should convert daily to RRULE:FREQ=DAILY', () => {
+    expect(occurrenceToRRule({ type: 'daily' })).toBe('RRULE:FREQ=DAILY');
+  });
+
+  it('should convert weekDays to RRULE with BYDAY', () => {
+    expect(occurrenceToRRule({ type: 'weekDays', days: [0, 1, 6] })).toBe(
+      'RRULE:FREQ=WEEKLY;BYDAY=SU,MO,SA',
+    );
+  });
+
+  it('should convert weekDays [1,3,5] to MO,WE,FR', () => {
+    expect(occurrenceToRRule({ type: 'weekDays', days: [1, 3, 5] })).toBe(
+      'RRULE:FREQ=WEEKLY;BYDAY=MO,WE,FR',
+    );
+  });
+
+  it('should convert intervalDays to RRULE with INTERVAL', () => {
+    expect(occurrenceToRRule({ type: 'intervalDays', interval: 3 })).toBe(
+      'RRULE:FREQ=DAILY;INTERVAL=3',
+    );
+  });
+
+  it('should handle all 7 days', () => {
+    expect(
+      occurrenceToRRule({ type: 'weekDays', days: [0, 1, 2, 3, 4, 5, 6] }),
+    ).toBe('RRULE:FREQ=WEEKLY;BYDAY=SU,MO,TU,WE,TH,FR,SA');
+  });
+});
+
+// ─── mapTimeOfDays ────────────────────────────────────
+
+describe('mapTimeOfDays', () => {
   it('should return ["anytime"] for empty array', () => {
-    expect(mapTimeOfDay([])).toEqual(['anytime']);
+    expect(mapTimeOfDays([])).toEqual(['anytime']);
+  });
+
+  it('should map time-of-day names to lowercase', () => {
+    expect(
+      mapTimeOfDays([
+        { id: '1', name: 'Morning' },
+        { id: '2', name: 'Evening' },
+      ]),
+    ).toEqual(['morning', 'evening']);
   });
 
   it('should filter invalid values', () => {
-    expect(mapTimeOfDay(['morning', 'invalid', 'evening'])).toEqual([
-      'morning',
-      'evening',
-    ]);
+    expect(
+      mapTimeOfDays([
+        { id: '1', name: 'Morning' },
+        { id: '2', name: 'CustomTime' },
+        { id: '3', name: 'Night' },
+      ]),
+    ).toEqual(['morning', 'night']);
   });
 
   it('should return ["anytime"] when all values are invalid', () => {
-    expect(mapTimeOfDay(['invalid1', 'invalid2'])).toEqual(['anytime']);
-  });
-
-  it('should pass through valid values', () => {
-    expect(mapTimeOfDay(['morning', 'afternoon', 'evening', 'night'])).toEqual([
-      'morning',
-      'afternoon',
-      'evening',
-      'night',
+    expect(mapTimeOfDays([{ id: '1', name: 'CustomTime' }])).toEqual([
+      'anytime',
     ]);
-  });
-});
-
-// ─── safePriorityToInt ────────────────────────────────
-
-describe('safePriorityToInt', () => {
-  it.each([
-    { name: 'normal', priority: 5, want: 5 },
-    { name: 'zero', priority: 0, want: 0 },
-    { name: 'negative normal', priority: -1, want: -1 },
-    { name: 'very large', priority: 1e18, want: 0 },
-    { name: 'very small', priority: -1e18, want: 0 },
-    { name: 'NaN', priority: NaN, want: 0 },
-    { name: 'positive Infinity', priority: Infinity, want: 0 },
-    { name: 'negative Infinity', priority: -Infinity, want: 0 },
-  ])('$name: $priority → $want', ({ priority, want }) => {
-    expect(safePriorityToInt(priority)).toBe(want);
-  });
-});
-
-// ─── transformLog ─────────────────────────────────────
-
-describe('transformLog', () => {
-  it('should transform a basic log', () => {
-    const l: HabitifyLog = {
-      id: 'log-1',
-      habit_id: 'h-1',
-      value: 1,
-      created_date: '2024-01-15T10:30:00+00:00',
-      unit_type: 'count',
-    };
-
-    const result = transformLog(l, 'habity-habit-1', 'user-1', 'UTC');
-
-    expect(result.user_id).toBe('user-1');
-    expect(result.habit_id).toBe('habity-habit-1');
-    expect(result.value).toBe(1);
-    expect(result.target_date).toBe('2024-01-15');
-    expect(result.status).toBe('completed');
-    expect(result.external_id).toBe('log-1');
-    expect(result.completed_at).toBe('2024-01-15T10:30:00+00:00');
-  });
-
-  describe('timezone conversion', () => {
-    it.each([
-      {
-        name: 'UTC midnight stays same date in UTC',
-        utcTime: '2026-02-10T00:00:00+00:00',
-        timezone: 'UTC',
-        wantDate: '2026-02-10',
-      },
-      {
-        name: 'UTC 23:00 becomes next day in JST',
-        utcTime: '2026-02-09T23:00:00+00:00',
-        timezone: 'Asia/Tokyo',
-        wantDate: '2026-02-10',
-      },
-      {
-        name: 'UTC 14:00 stays same day in JST (23:00 JST)',
-        utcTime: '2026-02-10T14:00:00+00:00',
-        timezone: 'Asia/Tokyo',
-        wantDate: '2026-02-10',
-      },
-      {
-        name: 'UTC 15:00 becomes next day in JST (00:00 JST)',
-        utcTime: '2026-02-10T15:00:00+00:00',
-        timezone: 'Asia/Tokyo',
-        wantDate: '2026-02-11',
-      },
-    ])('$name', ({ utcTime, timezone, wantDate }) => {
-      const l: HabitifyLog = {
-        id: 'log-1',
-        habit_id: 'h-1',
-        value: 1,
-        created_date: utcTime,
-        unit_type: 'count',
-      };
-
-      const result = transformLog(l, 'habity-habit-1', 'user-1', timezone);
-      expect(result.target_date).toBe(wantDate);
-    });
   });
 });

--- a/src/lib/habitify/__tests__/types.test.ts
+++ b/src/lib/habitify/__tests__/types.test.ts
@@ -77,10 +77,13 @@ describe('Habitify v2 Zod schemas', () => {
       expect(HabitifyOccurrenceSchema.parse(data)).toEqual(data);
     });
 
-    it('should reject unknown occurrence type', () => {
-      expect(() =>
-        HabitifyOccurrenceSchema.parse({ type: 'unknown' }),
-      ).toThrow(ZodError);
+    it('should accept an unknown occurrence type via the passthrough fallback', () => {
+      const data = { type: 'timesPerWeek', times: 3 };
+      expect(HabitifyOccurrenceSchema.parse(data)).toEqual(data);
+    });
+
+    it('should reject an occurrence with no type', () => {
+      expect(() => HabitifyOccurrenceSchema.parse({})).toThrow(ZodError);
     });
   });
 
@@ -129,6 +132,16 @@ describe('Habitify v2 Zod schemas', () => {
       const withExtra = { ...validHabit, unknown_field: true };
       const parsed = HabitifyHabitSchema.parse(withExtra);
       expect((parsed as Record<string, unknown>)['unknown_field']).toBeUndefined();
+    });
+
+    it('should accept a habit with colorHex: null', () => {
+      const data = { ...validHabit, colorHex: null };
+      expect(HabitifyHabitSchema.parse(data)).toMatchObject(data);
+    });
+
+    it('should accept a habit with colorHex omitted', () => {
+      const { colorHex: _colorHex, ...noColorHex } = validHabit;
+      expect(() => HabitifyHabitSchema.parse(noColorHex)).not.toThrow();
     });
   });
 

--- a/src/lib/habitify/__tests__/types.test.ts
+++ b/src/lib/habitify/__tests__/types.test.ts
@@ -3,38 +3,83 @@ import { ZodError } from 'zod';
 import {
   HabitifyAreaSchema,
   HabitifyGoalSchema,
+  HabitifyOccurrenceSchema,
   HabitifyHabitSchema,
-  HabitifyLogSchema,
-  HabitifyResponseSchema,
+  HabitifyDailyProgressSchema,
+  HabitifyStatisticsSchema,
+  HabitifyV2ResponseSchema,
+  HabitifyPaginationSchema,
 } from '../types';
 
-describe('Habitify Zod schemas', () => {
+describe('Habitify v2 Zod schemas', () => {
   describe('HabitifyAreaSchema', () => {
     it('should accept a valid area', () => {
       const data = { id: 'area-1', name: 'Health' };
-      expect(HabitifyAreaSchema.parse(data)).toEqual(data);
+      expect(HabitifyAreaSchema.parse(data)).toMatchObject(data);
+    });
+
+    it('should accept an area with optional fields', () => {
+      const data = {
+        id: 'area-1',
+        name: 'Health',
+        colorHex: '#FF6B6B',
+        icon: 'heart',
+        createdAt: '2024-01-01T00:00:00Z',
+      };
+      expect(HabitifyAreaSchema.parse(data)).toMatchObject(data);
     });
 
     it('should reject area with missing name', () => {
-      expect(() => HabitifyAreaSchema.parse({ id: 'area-1' })).toThrow(
-        ZodError,
-      );
+      expect(() => HabitifyAreaSchema.parse({ id: 'area-1' })).toThrow(ZodError);
     });
   });
 
   describe('HabitifyGoalSchema', () => {
     it('should accept a valid goal', () => {
-      const data = { unit_type: 'count', value: 1, periodicity: 'daily' };
+      const data = {
+        id: 'goal-1',
+        createdAt: '2024-01-01T00:00:00Z',
+        periodicity: 'daily',
+        value: 5,
+        unit: 'rep',
+        isActive: true,
+      };
       expect(HabitifyGoalSchema.parse(data)).toEqual(data);
     });
 
     it('should reject goal with string value', () => {
       expect(() =>
         HabitifyGoalSchema.parse({
-          unit_type: 'count',
-          value: 'one',
+          id: 'goal-1',
+          createdAt: '2024-01-01T00:00:00Z',
           periodicity: 'daily',
+          value: 'one',
+          unit: 'rep',
+          isActive: true,
         }),
+      ).toThrow(ZodError);
+    });
+  });
+
+  describe('HabitifyOccurrenceSchema', () => {
+    it('should accept daily occurrence', () => {
+      const data = { type: 'daily' as const };
+      expect(HabitifyOccurrenceSchema.parse(data)).toEqual(data);
+    });
+
+    it('should accept weekDays occurrence', () => {
+      const data = { type: 'weekDays' as const, days: [1, 3, 5] };
+      expect(HabitifyOccurrenceSchema.parse(data)).toEqual(data);
+    });
+
+    it('should accept intervalDays occurrence', () => {
+      const data = { type: 'intervalDays' as const, interval: 3 };
+      expect(HabitifyOccurrenceSchema.parse(data)).toEqual(data);
+    });
+
+    it('should reject unknown occurrence type', () => {
+      expect(() =>
+        HabitifyOccurrenceSchema.parse({ type: 'unknown' }),
       ).toThrow(ZodError);
     });
   });
@@ -43,24 +88,36 @@ describe('Habitify Zod schemas', () => {
     const validHabit = {
       id: 'habit-1',
       name: 'Morning Run',
-      is_archived: false,
-      start_date: '2024-01-01T00:00:00+00:00',
-      time_of_day: ['morning'],
-      area: { id: 'area-1', name: 'Health' },
-      recurrence: 'RRULE:FREQ=DAILY',
-      goal: { unit_type: 'count', value: 1, periodicity: 'daily' },
-      log_method: 'check',
-      priority: 1,
-      created_date: '2024-01-01T00:00:00+00:00',
+      icon: null,
+      colorHex: '#FF6B6B',
+      type: 'good',
+      description: null,
+      occurrence: { type: 'daily' as const },
+      startDate: '2024-01-01',
+      createdAt: '2024-01-01T00:00:00Z',
+      isArchived: false,
+      logMethod: 'manual',
+      goals: [
+        {
+          id: 'goal-1',
+          createdAt: '2024-01-01T00:00:00Z',
+          periodicity: 'daily',
+          value: 1,
+          unit: 'rep',
+          isActive: true,
+        },
+      ],
+      areas: [{ id: 'area-1', name: 'Health' }],
+      timeOfDays: [{ id: 'tod-1', name: 'Morning' }],
     };
 
     it('should accept a valid habit', () => {
-      expect(HabitifyHabitSchema.parse(validHabit)).toEqual(validHabit);
+      expect(HabitifyHabitSchema.parse(validHabit)).toMatchObject(validHabit);
     });
 
-    it('should accept a habit with null area and goal', () => {
-      const data = { ...validHabit, area: null, goal: null };
-      expect(HabitifyHabitSchema.parse(data)).toEqual(data);
+    it('should accept a habit with empty goals and areas', () => {
+      const data = { ...validHabit, goals: [], areas: [], timeOfDays: [] };
+      expect(HabitifyHabitSchema.parse(data)).toMatchObject(data);
     });
 
     it('should reject a habit with missing id', () => {
@@ -71,51 +128,92 @@ describe('Habitify Zod schemas', () => {
     it('should strip unknown fields', () => {
       const withExtra = { ...validHabit, unknown_field: true };
       const parsed = HabitifyHabitSchema.parse(withExtra);
-      expect(parsed).toEqual(validHabit);
       expect((parsed as Record<string, unknown>)['unknown_field']).toBeUndefined();
     });
   });
 
-  describe('HabitifyLogSchema', () => {
-    const validLog = {
-      id: 'log-1',
-      habit_id: 'habit-1',
-      value: 1,
-      created_date: '2024-01-15T10:30:00+00:00',
-      unit_type: 'count',
-    };
-
-    it('should accept a valid log', () => {
-      expect(HabitifyLogSchema.parse(validLog)).toEqual(validLog);
+  describe('HabitifyDailyProgressSchema', () => {
+    it('should accept valid daily progress', () => {
+      const data = { date: '2024-01-15', totalLog: 3.5, status: 'completed' };
+      expect(HabitifyDailyProgressSchema.parse(data)).toEqual(data);
     });
 
-    it('should reject a log with missing habit_id', () => {
-      const { habit_id: _, ...noHabitId } = validLog;
-      expect(() => HabitifyLogSchema.parse(noHabitId)).toThrow(ZodError);
+    it('should reject missing status', () => {
+      expect(() =>
+        HabitifyDailyProgressSchema.parse({ date: '2024-01-15', totalLog: 1 }),
+      ).toThrow(ZodError);
     });
   });
 
-  describe('HabitifyResponseSchema', () => {
-    it('should accept a valid response with habit array', () => {
-      const schema = HabitifyResponseSchema(HabitifyHabitSchema.array());
+  describe('HabitifyStatisticsSchema', () => {
+    const validStats = {
+      id: 'habit-1',
+      name: 'Morning Run',
+      type: 'good',
+      totalLogs: 10,
+      skips: 2,
+      fails: 1,
+      completions: 7,
+      unit: { id: 'unit-1', name: 'Repetition', symbol: 'rep' },
+      periodicity: 'daily',
+      avg: 1.5,
+      dailyProgress: [
+        { date: '2024-01-15', totalLog: 1, status: 'completed' },
+        { date: '2024-01-16', totalLog: 0, status: 'skipped' },
+      ],
+    };
+
+    it('should accept valid statistics', () => {
+      expect(HabitifyStatisticsSchema.parse(validStats)).toMatchObject(validStats);
+    });
+
+    it('should accept statistics with null unit', () => {
+      const data = { ...validStats, unit: null };
+      expect(HabitifyStatisticsSchema.parse(data)).toMatchObject(data);
+    });
+
+    it('should accept statistics with empty dailyProgress', () => {
+      const data = { ...validStats, dailyProgress: [] };
+      expect(HabitifyStatisticsSchema.parse(data)).toMatchObject(data);
+    });
+  });
+
+  describe('HabitifyV2ResponseSchema', () => {
+    it('should accept a response with habit array and pagination', () => {
+      const schema = HabitifyV2ResponseSchema(HabitifyHabitSchema.array());
       const data = {
-        message: 'OK',
         data: [],
-        status: true,
-        version: 'v1.2',
+        pagination: { total: 0, limit: 50, offset: 0 },
       };
       expect(schema.parse(data)).toEqual(data);
     });
 
-    it('should reject a response with wrong status type', () => {
-      const schema = HabitifyResponseSchema(HabitifyHabitSchema.array());
+    it('should accept a response without pagination', () => {
+      const schema = HabitifyV2ResponseSchema(HabitifyStatisticsSchema);
+      const data = {
+        data: {
+          id: 'h-1',
+          name: 'Test',
+          totalLogs: 0,
+          skips: 0,
+          fails: 0,
+          completions: 0,
+          dailyProgress: [],
+        },
+      };
+      expect(schema.parse(data)).toMatchObject(data);
+    });
+  });
+
+  describe('HabitifyPaginationSchema', () => {
+    it('should accept valid pagination', () => {
+      const data = { total: 100, limit: 50, offset: 0 };
+      expect(HabitifyPaginationSchema.parse(data)).toEqual(data);
+    });
+
+    it('should reject missing total', () => {
       expect(() =>
-        schema.parse({
-          message: 'OK',
-          data: [],
-          status: 'yes',
-          version: 'v1.2',
-        }),
+        HabitifyPaginationSchema.parse({ limit: 50, offset: 0 }),
       ).toThrow(ZodError);
     });
   });

--- a/src/lib/habitify/client.ts
+++ b/src/lib/habitify/client.ts
@@ -1,38 +1,28 @@
 /**
- * Habitify API client
- * Ported from: backend/internal/habitify/client.go
+ * Habitify API v2 client
+ * API docs: https://api-docs.habitify.me/api#description/introduction
  */
 
-import type { HabitifyHabit, HabitifyLog } from './types';
+import type { HabitifyHabit, HabitifyStatistics } from './types';
 import {
   HabitifyHabitSchema,
-  HabitifyLogSchema,
-  HabitifyResponseSchema,
+  HabitifyStatisticsSchema,
+  HabitifyV2ResponseSchema,
 } from './types';
 
-const DEFAULT_BASE_URL = 'https://api.habitify.me';
+const DEFAULT_BASE_URL = 'https://api.habitify.me/v2';
+
+/** Max items per page for the habits list endpoint. */
+const PAGE_LIMIT = 100;
 
 /**
- * Format a Date to the Habitify date format: YYYY-MM-DDThh:mm:ss±hh:mm
- * Habitify API does not accept "Z" for UTC — it requires ±hh:mm offset.
+ * Format a Date to YYYY-MM-DD (the only date format v2 uses).
  */
-export function formatHabitifyDate(date: Date): string {
-  const pad = (n: number) => String(n).padStart(2, '0');
-
+export function formatDate(date: Date): string {
   const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-  const hours = pad(date.getHours());
-  const minutes = pad(date.getMinutes());
-  const seconds = pad(date.getSeconds());
-
-  const offsetMinutes = -date.getTimezoneOffset();
-  const sign = offsetMinutes >= 0 ? '+' : '-';
-  const absOffset = Math.abs(offsetMinutes);
-  const offsetH = pad(Math.floor(absOffset / 60));
-  const offsetM = pad(absOffset % 60);
-
-  return `${year}-${month}-${day}T${hours}:${minutes}:${seconds}${sign}${offsetH}:${offsetM}`;
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
 }
 
 async function doRequest(
@@ -43,70 +33,85 @@ async function doRequest(
   return fetch(`${baseURL}${path}`, {
     method: 'GET',
     headers: {
-      Authorization: apiKey,
+      'X-API-Key': apiKey,
     },
   });
 }
 
-/** Fetch all habits from the Habitify API. */
+/**
+ * Fetch all habits from the Habitify API v2 (paginated).
+ * Fetches both active and archived habits.
+ */
 export async function getHabits(
   apiKey: string,
   baseURL = DEFAULT_BASE_URL,
 ): Promise<HabitifyHabit[]> {
-  const resp = await doRequest(baseURL, apiKey, '/habits');
+  const allHabits: HabitifyHabit[] = [];
 
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new Error(`get habits: status ${resp.status}: ${body}`);
+  for (const archived of [false, true]) {
+    let offset = 0;
+    // eslint-disable-next-line no-constant-condition
+    while (true) {
+      const params = new URLSearchParams({
+        limit: String(PAGE_LIMIT),
+        offset: String(offset),
+        archived: String(archived),
+      });
+      const resp = await doRequest(baseURL, apiKey, `/habits?${params}`);
+
+      if (!resp.ok) {
+        const body = await resp.text().catch(() => '');
+        throw new Error(`get habits: status ${resp.status}: ${body}`);
+      }
+
+      const json: unknown = await resp.json();
+      const result = HabitifyV2ResponseSchema(
+        HabitifyHabitSchema.array(),
+      ).parse(json);
+
+      allHabits.push(...result.data);
+
+      // Check if there are more pages
+      if (!result.pagination || offset + PAGE_LIMIT >= result.pagination.total) {
+        break;
+      }
+      offset += PAGE_LIMIT;
+    }
   }
 
-  const json: unknown = await resp.json();
-  const result = HabitifyResponseSchema(
-    HabitifyHabitSchema.array().nullable(),
-  ).parse(json);
-
-  if (!result.status) {
-    throw new Error(`get habits: API returned error: ${result.message}`);
-  }
-
-  return result.data ?? [];
+  return allHabits;
 }
 
-/** Fetch logs for a specific habit within a date range. */
-export async function getLogs(
+/**
+ * Fetch statistics (including dailyProgress) for a specific habit.
+ */
+export async function getStatistics(
   apiKey: string,
   habitId: string,
-  from: Date,
-  to: Date,
+  startDate?: string,
+  endDate?: string,
   baseURL = DEFAULT_BASE_URL,
-): Promise<HabitifyLog[]> {
-  const params = new URLSearchParams({
-    from: formatHabitifyDate(from),
-    to: formatHabitifyDate(to),
-  });
-  const path = `/logs/${habitId}?${params.toString()}`;
+): Promise<HabitifyStatistics> {
+  const params = new URLSearchParams();
+  if (startDate) params.set('startDate', startDate);
+  if (endDate) params.set('endDate', endDate);
+
+  const query = params.toString();
+  const path = `/habits/${habitId}/statistics${query ? `?${query}` : ''}`;
 
   const resp = await doRequest(baseURL, apiKey, path);
 
   if (!resp.ok) {
     const body = await resp.text().catch(() => '');
     throw new Error(
-      `get logs for habit ${habitId}: status ${resp.status}: ${body}`,
+      `get statistics for habit ${habitId}: status ${resp.status}: ${body}`,
     );
   }
 
   const json: unknown = await resp.json();
-  const result = HabitifyResponseSchema(
-    HabitifyLogSchema.array().nullable(),
-  ).parse(json);
+  const result = HabitifyV2ResponseSchema(HabitifyStatisticsSchema).parse(json);
 
-  if (!result.status) {
-    throw new Error(
-      `get logs for habit ${habitId}: API returned error: ${result.message}`,
-    );
-  }
-
-  return result.data ?? [];
+  return result.data;
 }
 
 /** Validate an API key by calling getHabits. */

--- a/src/lib/habitify/client.ts
+++ b/src/lib/habitify/client.ts
@@ -6,6 +6,7 @@
 import type { HabitifyHabit, HabitifyStatistics } from './types';
 import {
   HabitifyHabitSchema,
+  HabitifyHabitsEnvelopeSchema,
   HabitifyStatisticsSchema,
   HabitifyV2ResponseSchema,
 } from './types';
@@ -14,6 +15,12 @@ const DEFAULT_BASE_URL = 'https://api.habitify.me/v2';
 
 /** Max items per page for the habits list endpoint. */
 const PAGE_LIMIT = 100;
+
+/** Max number of retries for 429/5xx responses (in addition to the initial attempt). */
+const MAX_RETRIES = 3;
+
+/** Base delay for exponential backoff between retries, in milliseconds. */
+const RETRY_BASE_DELAY_MS = 500;
 
 /**
  * Format a Date to YYYY-MM-DD (the only date format v2 uses).
@@ -25,28 +32,78 @@ export function formatDate(date: Date): string {
   return `${year}-${month}-${day}`;
 }
 
+function isRetryableStatus(status: number): boolean {
+  return status === 429 || status >= 500;
+}
+
+async function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/** Injectable backoff delay, overridable in tests to avoid real waits. */
+let retrySleep: (ms: number) => Promise<void> = defaultSleep;
+
+/** Test-only hook: override the retry backoff delay implementation. */
+export function __setRetrySleepForTesting(fn: (ms: number) => Promise<void>): void {
+  retrySleep = fn;
+}
+
+/**
+ * Issue a GET request, retrying on 429/5xx responses with exponential
+ * backoff (respecting a `Retry-After` header in seconds, when present).
+ * Non-retryable errors (other 4xx) are returned immediately for the caller
+ * to handle.
+ */
 async function doRequest(
   baseURL: string,
   apiKey: string,
   path: string,
 ): Promise<Response> {
-  return fetch(`${baseURL}${path}`, {
-    method: 'GET',
-    headers: {
-      'X-API-Key': apiKey,
-    },
-  });
+  let attempt = 0;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const resp = await fetch(`${baseURL}${path}`, {
+      method: 'GET',
+      headers: {
+        'X-API-Key': apiKey,
+      },
+    });
+
+    if (resp.ok || !isRetryableStatus(resp.status) || attempt >= MAX_RETRIES) {
+      return resp;
+    }
+
+    const retryAfterHeader = resp.headers?.get?.('Retry-After');
+    const retryAfterSeconds = retryAfterHeader ? Number(retryAfterHeader) : NaN;
+    const delayMs = Number.isFinite(retryAfterSeconds)
+      ? retryAfterSeconds * 1000
+      : RETRY_BASE_DELAY_MS * 2 ** attempt;
+
+    await retrySleep(delayMs);
+    attempt += 1;
+  }
+}
+
+/** Result of {@link getHabits}: successfully parsed habits plus any per-item errors. */
+export interface GetHabitsResult {
+  habits: HabitifyHabit[];
+  errors: string[];
 }
 
 /**
  * Fetch all habits from the Habitify API v2 (paginated).
  * Fetches both active and archived habits.
+ *
+ * Each habit is parsed individually — a single malformed habit is skipped
+ * (and recorded in `errors`) instead of failing the entire import.
  */
 export async function getHabits(
   apiKey: string,
   baseURL = DEFAULT_BASE_URL,
-): Promise<HabitifyHabit[]> {
+): Promise<GetHabitsResult> {
   const allHabits: HabitifyHabit[] = [];
+  const errors: string[] = [];
 
   for (const archived of [false, true]) {
     let offset = 0;
@@ -65,25 +122,36 @@ export async function getHabits(
       }
 
       const json: unknown = await resp.json();
-      const result = HabitifyV2ResponseSchema(
-        HabitifyHabitSchema.array(),
-      ).parse(json);
+      const envelope = HabitifyHabitsEnvelopeSchema.parse(json);
+      const rawHabits = envelope.data ?? [];
 
-      allHabits.push(...result.data);
+      rawHabits.forEach((rawHabit, index) => {
+        const parsed = HabitifyHabitSchema.safeParse(rawHabit);
+        if (parsed.success) {
+          allHabits.push(parsed.data);
+        } else {
+          const name =
+            typeof rawHabit === 'object' && rawHabit !== null && 'name' in rawHabit
+              ? String((rawHabit as { name?: unknown }).name)
+              : `index ${offset + index}`;
+          errors.push(`habit "${name}": ${parsed.error.message}`);
+        }
+      });
 
       // Check if there are more pages
-      if (!result.pagination || offset + PAGE_LIMIT >= result.pagination.total) {
+      if (!envelope.pagination || offset + PAGE_LIMIT >= envelope.pagination.total) {
         break;
       }
       offset += PAGE_LIMIT;
     }
   }
 
-  return allHabits;
+  return { habits: allHabits, errors };
 }
 
 /**
  * Fetch statistics (including dailyProgress) for a specific habit.
+ * Follows pagination (when present) and merges `dailyProgress` across pages.
  */
 export async function getStatistics(
   apiKey: string,
@@ -92,26 +160,43 @@ export async function getStatistics(
   endDate?: string,
   baseURL = DEFAULT_BASE_URL,
 ): Promise<HabitifyStatistics> {
-  const params = new URLSearchParams();
-  if (startDate) params.set('startDate', startDate);
-  if (endDate) params.set('endDate', endDate);
+  let offset = 0;
+  let merged: HabitifyStatistics | undefined;
 
-  const query = params.toString();
-  const path = `/habits/${habitId}/statistics${query ? `?${query}` : ''}`;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const params = new URLSearchParams();
+    if (startDate) params.set('startDate', startDate);
+    if (endDate) params.set('endDate', endDate);
+    if (offset > 0) params.set('offset', String(offset));
 
-  const resp = await doRequest(baseURL, apiKey, path);
+    const query = params.toString();
+    const path = `/habits/${habitId}/statistics${query ? `?${query}` : ''}`;
 
-  if (!resp.ok) {
-    const body = await resp.text().catch(() => '');
-    throw new Error(
-      `get statistics for habit ${habitId}: status ${resp.status}: ${body}`,
-    );
+    const resp = await doRequest(baseURL, apiKey, path);
+
+    if (!resp.ok) {
+      const body = await resp.text().catch(() => '');
+      throw new Error(
+        `get statistics for habit ${habitId}: status ${resp.status}: ${body}`,
+      );
+    }
+
+    const json: unknown = await resp.json();
+    const result = HabitifyV2ResponseSchema(HabitifyStatisticsSchema).parse(json);
+
+    merged = merged
+      ? { ...result.data, dailyProgress: [...merged.dailyProgress, ...result.data.dailyProgress] }
+      : result.data;
+
+    const { pagination } = result;
+    if (!pagination || offset + pagination.limit >= pagination.total) {
+      break;
+    }
+    offset += pagination.limit;
   }
 
-  const json: unknown = await resp.json();
-  const result = HabitifyV2ResponseSchema(HabitifyStatisticsSchema).parse(json);
-
-  return result.data;
+  return merged;
 }
 
 /** Validate an API key by calling getHabits. */

--- a/src/lib/habitify/import-service.ts
+++ b/src/lib/habitify/import-service.ts
@@ -1,13 +1,13 @@
 /**
- * Habitify → Habity import service
+ * Habitify v2 → Habity import service
  *
  * Uses batch upsert to minimize API requests to Supabase.
  */
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { HabitifyHabit } from './types';
-import { getHabits, getLogs } from './client';
-import { transformHabit, transformLog } from './transform';
+import { getHabits, getStatistics, formatDate } from './client';
+import { transformHabit, transformDailyProgress } from './transform';
 
 export interface ImportParams {
   apiKey: string;
@@ -27,10 +27,9 @@ export interface ImportResult {
 /** Max rows per upsert request to stay within Supabase payload limits. */
 const BATCH_SIZE = 500;
 
-/** Run the full Habitify → Habity import. */
+/** Run the full Habitify v2 → Habity import. */
 export async function runImport(params: ImportParams): Promise<ImportResult> {
-  const { apiKey, importHabits, importLogs, timezone, userId, supabase } =
-    params;
+  const { apiKey, importHabits, importLogs, userId, supabase } = params;
 
   // 1. Fetch habits (also validates API key)
   const habits = await getHabits(apiKey);
@@ -94,7 +93,7 @@ export async function runImport(params: ImportParams): Promise<ImportResult> {
     }
   }
 
-  // 4. Import logs (batch upsert per habit, chunked)
+  // 4. Import logs via statistics endpoint (batch upsert per habit, chunked)
   if (importLogs) {
     for (const h of habits) {
       const habityHabitId = habitIdMap.get(h.id);
@@ -102,28 +101,27 @@ export async function runImport(params: ImportParams): Promise<ImportResult> {
         continue;
       }
 
-      const from = h.start_date
-        ? new Date(h.start_date)
-        : new Date('2020-01-01T00:00:00Z');
-      const to = new Date();
-
-      let logs;
+      let stats;
       try {
-        logs = await getLogs(apiKey, h.id, from, to);
+        const endDate = formatDate(new Date());
+        stats = await getStatistics(apiKey, h.id, h.startDate, endDate);
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
-        result.errors.push(`logs for "${h.name}": ${msg}`);
+        result.errors.push(`statistics for "${h.name}": ${msg}`);
         continue;
       }
 
-      // Transform all logs for this habit
+      // Transform dailyProgress entries
       const rows: HabityLogRow[] = [];
-      for (const l of logs) {
+      for (const dp of stats.dailyProgress) {
         try {
-          rows.push(transformLog(l, habityHabitId, userId, timezone));
+          const log = transformDailyProgress(dp, habityHabitId, userId);
+          if (log) {
+            rows.push(log);
+          }
         } catch (e) {
           const msg = e instanceof Error ? e.message : String(e);
-          result.errors.push(`log ${l.id}: ${msg}`);
+          result.errors.push(`log ${dp.date}: ${msg}`);
         }
       }
 
@@ -158,15 +156,15 @@ async function ensureCategories(
 ): Promise<Record<string, string>> {
   const categoryMap: Record<string, string> = {};
 
-  // Collect unique areas
+  // Collect unique areas (use first area from each habit)
   const areas: { id: string; name: string }[] = [];
   const seen = new Set<string>();
   for (const h of habits) {
-    if (!h.area || seen.has(h.area.id)) {
-      continue;
-    }
-    seen.add(h.area.id);
-    areas.push(h.area);
+    if (h.areas.length === 0) continue;
+    const area = h.areas[0];
+    if (seen.has(area.id)) continue;
+    seen.add(area.id);
+    areas.push({ id: area.id, name: area.name });
   }
 
   if (areas.length === 0) {
@@ -234,5 +232,5 @@ interface HabityLogRow {
   target_date: string;
   completed_at: string;
   status: string;
-  external_id: string;
+  external_id: string | null;
 }

--- a/src/lib/habitify/import-service.ts
+++ b/src/lib/habitify/import-service.ts
@@ -13,7 +13,6 @@ export interface ImportParams {
   apiKey: string;
   importHabits: boolean;
   importLogs: boolean;
-  timezone: string;
   userId: string;
   supabase: SupabaseClient;
 }
@@ -31,21 +30,37 @@ const BATCH_SIZE = 500;
 export async function runImport(params: ImportParams): Promise<ImportResult> {
   const { apiKey, importHabits, importLogs, userId, supabase } = params;
 
-  // 1. Fetch habits (also validates API key)
-  const habits = await getHabits(apiKey);
-
   const result: ImportResult = {
     habits_imported: 0,
     logs_imported: 0,
     errors: [],
   };
 
+  // 1. Fetch habits (also validates API key)
+  let habits: HabitifyHabit[];
+  try {
+    const fetched = await getHabits(apiKey);
+    habits = fetched.habits;
+    result.errors.push(...fetched.errors);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result.errors.push(`Habitify API: ${msg}`);
+    return result;
+  }
+
   if (!importHabits && !importLogs) {
     return result;
   }
 
-  // 2. Extract areas → create categories
-  const categoryMap = await ensureCategories(supabase, userId, habits);
+  // 2. Extract areas → create categories. A failure here shouldn't block
+  // habit/log import — fall back to no categorization and keep going.
+  let categoryMap: Record<string, string> = {};
+  try {
+    categoryMap = await ensureCategories(supabase, userId, habits);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    result.errors.push(`categories: ${msg}`);
+  }
 
   // 3. Import habits (batch upsert)
   const habitIdMap = new Map<string, string>(); // habitify ID → habity ID
@@ -211,9 +226,9 @@ interface HabityHabitRow {
   description: string | null;
   category_id: string | null;
   tracking_type: string;
-  goal_value: number;
-  goal_unit: string;
-  goal_period: string;
+  goal_value: number | null;
+  goal_unit: string | null;
+  goal_period: string | null;
   recurrence_rule: string | null;
   time_of_day: string[];
   reminder_enabled: boolean;

--- a/src/lib/habitify/transform.ts
+++ b/src/lib/habitify/transform.ts
@@ -1,9 +1,13 @@
 /**
- * Data transformation: Habitify → Habity
- * Ported from: backend/internal/service/transform.go
+ * Data transformation: Habitify v2 → Habity
  */
 
-import type { HabitifyHabit, HabitifyLog, HabitifyGoal } from './types';
+import type {
+  HabitifyHabit,
+  HabitifyGoal,
+  HabitifyOccurrence,
+  HabitifyDailyProgress,
+} from './types';
 
 // ─── Output types ──────────────────────────────────────
 
@@ -34,34 +38,33 @@ export interface HabityLog {
   target_date: string;
   completed_at: string;
   status: string;
-  external_id: string;
+  external_id: string | null;
 }
 
 // ─── Main transform functions ──────────────────────────
 
-/** Convert a Habitify habit to a Habity habit. */
+/** Convert a Habitify v2 habit to a Habity habit. */
 export function transformHabit(
   h: HabitifyHabit,
   userId: string,
   categoryMap: Record<string, string>,
 ): HabityHabit {
-  const trackingType = mapLogMethod(h.log_method);
-  const { value: goalValue, unit: goalUnit, period: goalPeriod } = mapGoal(h.goal);
-  const status = mapStatus(h.is_archived);
-  const timeOfDay = mapTimeOfDay(h.time_of_day);
-  const startDate = h.start_date.slice(0, 10); // "YYYY-MM-DD"
-
-  const recurrenceRule = h.recurrence || null;
+  const activeGoal = findActiveGoal(h.goals);
+  const trackingType = inferTrackingType(activeGoal);
+  const { value: goalValue, unit: goalUnit, period: goalPeriod } = mapGoal(activeGoal);
+  const status = h.isArchived ? 'archived' : 'active';
+  const timeOfDay = mapTimeOfDays(h.timeOfDays);
+  const recurrenceRule = occurrenceToRRule(h.occurrence);
 
   let categoryId: string | null = null;
-  if (h.area && categoryMap[h.area.id]) {
-    categoryId = categoryMap[h.area.id];
+  if (h.areas.length > 0 && categoryMap[h.areas[0].id]) {
+    categoryId = categoryMap[h.areas[0].id];
   }
 
   return {
     user_id: userId,
     name: h.name,
-    description: null,
+    description: h.description ?? null,
     category_id: categoryId,
     tracking_type: trackingType,
     goal_value: goalValue,
@@ -70,55 +73,59 @@ export function transformHabit(
     recurrence_rule: recurrenceRule,
     time_of_day: timeOfDay,
     reminder_enabled: false,
-    start_date: startDate,
+    start_date: h.startDate,
     end_date: null,
     status,
-    sort_order: safePriorityToInt(h.priority),
+    sort_order: 0,
     external_id: h.id,
     external_source: 'habitify',
   };
 }
 
 /**
- * Convert a Habitify log to a Habity log.
- * @param timezone IANA timezone string (e.g. "Asia/Tokyo") to determine the correct target_date.
+ * Convert a Habitify v2 dailyProgress entry to a Habity log.
+ * Returns null if the status should not be imported (failed, inprogress).
  */
-export function transformLog(
-  l: HabitifyLog,
+export function transformDailyProgress(
+  dp: HabitifyDailyProgress,
   habityHabitId: string,
   userId: string,
-  timezone: string,
-): HabityLog {
-  const createdDate = new Date(l.created_date);
-  const targetDate = formatDateInTimezone(createdDate, timezone);
+): HabityLog | null {
+  if (dp.status !== 'completed' && dp.status !== 'skipped') {
+    return null;
+  }
 
   return {
     user_id: userId,
     habit_id: habityHabitId,
-    value: l.value,
-    target_date: targetDate,
-    completed_at: l.created_date,
-    status: 'completed',
-    external_id: l.id,
+    value: dp.totalLog,
+    target_date: dp.date,
+    completed_at: `${dp.date}T00:00:00`,
+    status: dp.status,
+    external_id: null,
   };
 }
 
-// ─── Mapping helpers ───────────────────────────────────
+// ─── Goal helpers ─────────────────────────────────────
 
-export function mapLogMethod(logMethod: string): string {
-  switch (logMethod) {
-    case 'check':
-      return 'boolean';
-    case 'measure':
-    case 'number':
-      return 'numeric';
-    case 'timer':
-      return 'duration';
-    default:
-      return 'boolean';
-  }
+/** Find the active goal, or return null if none. */
+export function findActiveGoal(goals: HabitifyGoal[]): HabitifyGoal | null {
+  return goals.find((g) => g.isActive) ?? goals[0] ?? null;
 }
 
+/** Infer tracking_type from the active goal's unit. */
+export function inferTrackingType(goal: HabitifyGoal | null): string {
+  if (!goal) return 'boolean';
+
+  const durationUnits = new Set(['sec', 'min', 'hr', 'ms']);
+  if (durationUnits.has(goal.unit)) {
+    return 'duration';
+  }
+
+  return 'numeric';
+}
+
+/** Extract goal value, unit, and period from a v2 goal. */
 export function mapGoal(goal: HabitifyGoal | null): {
   value: number;
   unit: string;
@@ -129,30 +136,69 @@ export function mapGoal(goal: HabitifyGoal | null): {
   }
   return {
     value: goal.value,
-    unit: mapGoalUnit(goal.unit_type),
+    unit: mapGoalUnit(goal.unit),
     period: mapGoalPeriod(goal.periodicity),
   };
 }
 
-export function mapGoalUnit(unitType: string): string {
-  switch (unitType) {
-    case 'count':
+/** Map v2 unit symbols to Habity goal_unit. */
+export function mapGoalUnit(unit: string): string {
+  switch (unit) {
+    case 'rep':
       return 'times';
-    case 'minute':
+    case 'min':
       return 'min';
-    case 'hour':
+    case 'hr':
       return 'hours';
-    case 'meter':
+    case 'sec':
+      return 'sec';
+    case 'ms':
+      return 'ms';
+    case 'm':
       return 'm';
-    case 'kilometer':
+    case 'kM':
       return 'km';
+    case 'ft':
+      return 'ft';
+    case 'yd':
+      return 'yd';
+    case 'mi':
+      return 'mi';
+    case 'kg':
+      return 'kg';
+    case 'g':
+      return 'g';
+    case 'mg':
+      return 'mg';
+    case 'oz':
+      return 'oz';
+    case 'lb':
+      return 'lb';
+    case 'L':
+      return 'L';
+    case 'mL':
+      return 'mL';
+    case 'fl oz':
+      return 'fl oz';
+    case 'cup':
+      return 'cup';
+    case 'kCal':
+      return 'kcal';
+    case 'cal':
+      return 'cal';
+    case 'kJ':
+      return 'kJ';
+    case 'J':
+      return 'J';
+    case 'step':
+      return 'steps';
+    case 'floor':
+      return 'floors';
+    case 'mcg':
+      return 'mcg';
     default:
-      return unitType;
+      return unit;
   }
-}
-
-function mapStatus(isArchived: boolean): string {
-  return isArchived ? 'archived' : 'active';
 }
 
 export function mapGoalPeriod(periodicity: string): string {
@@ -166,40 +212,43 @@ export function mapGoalPeriod(periodicity: string): string {
   }
 }
 
-export function mapTimeOfDay(times: string[]): string[] {
-  if (!times || times.length === 0) {
+// ─── Occurrence → RRULE ───────────────────────────────
+
+const DAY_ABBREVS = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
+
+/** Convert a v2 occurrence object to an RRULE string. */
+export function occurrenceToRRule(occurrence: HabitifyOccurrence): string | null {
+  switch (occurrence.type) {
+    case 'daily':
+      return 'RRULE:FREQ=DAILY';
+    case 'weekDays': {
+      const days = occurrence.days
+        .map((d) => DAY_ABBREVS[d])
+        .filter(Boolean)
+        .join(',');
+      return days ? `RRULE:FREQ=WEEKLY;BYDAY=${days}` : 'RRULE:FREQ=DAILY';
+    }
+    case 'intervalDays':
+      return `RRULE:FREQ=DAILY;INTERVAL=${occurrence.interval}`;
+    default:
+      return null;
+  }
+}
+
+// ─── TimeOfDay mapping ────────────────────────────────
+
+/** Map v2 timeOfDays objects to Habity time_of_day enum values. */
+export function mapTimeOfDays(
+  timeOfDays: { id: string; name: string }[],
+): string[] {
+  if (!timeOfDays || timeOfDays.length === 0) {
     return ['anytime'];
   }
 
   const valid = new Set(['anytime', 'morning', 'afternoon', 'evening', 'night']);
-  const result = times.filter((t) => valid.has(t));
+  const result = timeOfDays
+    .map((t) => t.name.toLowerCase())
+    .filter((name) => valid.has(name));
 
-  if (result.length === 0) {
-    return ['anytime'];
-  }
-  return result;
-}
-
-export function safePriorityToInt(p: number): number {
-  if (!Number.isFinite(p) || p > 2147483647 || p < -2147483648) {
-    return 0;
-  }
-  return Math.trunc(p);
-}
-
-// ─── Internal helpers ──────────────────────────────────
-
-function formatDateInTimezone(date: Date, timezone: string): string {
-  const parts = new Intl.DateTimeFormat('en-CA', {
-    timeZone: timezone,
-    year: 'numeric',
-    month: '2-digit',
-    day: '2-digit',
-  }).formatToParts(date);
-
-  const year = parts.find((p) => p.type === 'year')!.value;
-  const month = parts.find((p) => p.type === 'month')!.value;
-  const day = parts.find((p) => p.type === 'day')!.value;
-
-  return `${year}-${month}-${day}`;
+  return result.length > 0 ? result : ['anytime'];
 }

--- a/src/lib/habitify/transform.ts
+++ b/src/lib/habitify/transform.ts
@@ -17,9 +17,9 @@ export interface HabityHabit {
   description: string | null;
   category_id: string | null;
   tracking_type: string;
-  goal_value: number;
-  goal_unit: string;
-  goal_period: string;
+  goal_value: number | null;
+  goal_unit: string | null;
+  goal_period: string | null;
   recurrence_rule: string | null;
   time_of_day: string[];
   reminder_enabled: boolean;
@@ -113,7 +113,12 @@ export function findActiveGoal(goals: HabitifyGoal[]): HabitifyGoal | null {
   return goals.find((g) => g.isActive) ?? goals[0] ?? null;
 }
 
-/** Infer tracking_type from the active goal's unit. */
+/**
+ * Infer tracking_type from the active goal.
+ * Habitify represents simple checkbox ("just do it") habits as a goal of
+ * exactly 1 rep, so that combination maps back to 'boolean' rather than
+ * 'numeric'. Duration units always map to 'duration' regardless of value.
+ */
 export function inferTrackingType(goal: HabitifyGoal | null): string {
   if (!goal) return 'boolean';
 
@@ -122,22 +127,37 @@ export function inferTrackingType(goal: HabitifyGoal | null): string {
     return 'duration';
   }
 
+  if (goal.unit === 'rep' && goal.value === 1) {
+    return 'boolean';
+  }
+
   return 'numeric';
 }
 
-/** Extract goal value, unit, and period from a v2 goal. */
+/**
+ * Extract goal value, unit, and period from a v2 goal.
+ * If the goal's periodicity can't be mapped to a known period, the goal is
+ * not adopted at all (value/unit/period all null) rather than fabricating a
+ * period — the habit itself is still imported, just without a goal target.
+ */
 export function mapGoal(goal: HabitifyGoal | null): {
-  value: number;
-  unit: string;
-  period: string;
+  value: number | null;
+  unit: string | null;
+  period: string | null;
 } {
   if (!goal) {
     return { value: 1, unit: 'times', period: 'daily' };
   }
+
+  const period = mapGoalPeriod(goal.periodicity);
+  if (period === null) {
+    return { value: null, unit: null, period: null };
+  }
+
   return {
     value: goal.value,
     unit: mapGoalUnit(goal.unit),
-    period: mapGoalPeriod(goal.periodicity),
+    period,
   };
 }
 
@@ -201,14 +221,16 @@ export function mapGoalUnit(unit: string): string {
   }
 }
 
-export function mapGoalPeriod(periodicity: string): string {
+/** Map a v2 goal periodicity to a Habity goal_period, or null when unknown
+ * (e.g. 'yearly') rather than defaulting to 'daily'. */
+export function mapGoalPeriod(periodicity: string): string | null {
   switch (periodicity) {
     case 'daily':
     case 'weekly':
     case 'monthly':
       return periodicity;
     default:
-      return 'daily';
+      return null;
   }
 }
 
@@ -216,23 +238,31 @@ export function mapGoalPeriod(periodicity: string): string {
 
 const DAY_ABBREVS = ['SU', 'MO', 'TU', 'WE', 'TH', 'FR', 'SA'];
 
-/** Convert a v2 occurrence object to an RRULE string. */
+/**
+ * Convert a v2 occurrence object to an RRULE string.
+ * Unknown/future occurrence types (passed through by the schema so the whole
+ * habit doesn't fail to parse) fall back to null.
+ */
 export function occurrenceToRRule(occurrence: HabitifyOccurrence): string | null {
-  switch (occurrence.type) {
-    case 'daily':
-      return 'RRULE:FREQ=DAILY';
-    case 'weekDays': {
-      const days = occurrence.days
-        .map((d) => DAY_ABBREVS[d])
-        .filter(Boolean)
-        .join(',');
-      return days ? `RRULE:FREQ=WEEKLY;BYDAY=${days}` : 'RRULE:FREQ=DAILY';
-    }
-    case 'intervalDays':
-      return `RRULE:FREQ=DAILY;INTERVAL=${occurrence.interval}`;
-    default:
-      return null;
+  if (occurrence.type === 'daily') {
+    return 'RRULE:FREQ=DAILY';
   }
+
+  if (occurrence.type === 'weekDays') {
+    const rawDays = 'days' in occurrence ? occurrence.days : undefined;
+    const days = Array.isArray(rawDays) ? (rawDays as number[]) : [];
+    const dayNames = days.map((d) => DAY_ABBREVS[d]).filter(Boolean).join(',');
+    return dayNames ? `RRULE:FREQ=WEEKLY;BYDAY=${dayNames}` : 'RRULE:FREQ=DAILY';
+  }
+
+  if (occurrence.type === 'intervalDays') {
+    const rawInterval = 'interval' in occurrence ? occurrence.interval : undefined;
+    return typeof rawInterval === 'number'
+      ? `RRULE:FREQ=DAILY;INTERVAL=${rawInterval}`
+      : null;
+  }
+
+  return null;
 }
 
 // ─── TimeOfDay mapping ────────────────────────────────

--- a/src/lib/habitify/types.ts
+++ b/src/lib/habitify/types.ts
@@ -1,62 +1,122 @@
 /**
- * Habitify API types — Zod schemas with inferred TypeScript types
- * Ported from: backend/internal/habitify/types.go
+ * Habitify API v2 types — Zod schemas with inferred TypeScript types
+ * API docs: https://api-docs.habitify.me/api#description/introduction
  */
 
 import { z } from 'zod';
+
+// ─── Shared / embedded objects ────────────────────────
 
 /** An area (category) embedded in a Habit. */
 export const HabitifyAreaSchema = z.object({
   id: z.string(),
   name: z.string(),
+  colorHex: z.string().nullable().optional(),
+  icon: z.string().nullable().optional(),
+  createdAt: z.string().optional(),
 });
 export type HabitifyArea = z.infer<typeof HabitifyAreaSchema>;
 
-/** A habit's goal configuration. */
+/** A habit's goal configuration (v2). */
 export const HabitifyGoalSchema = z.object({
-  unit_type: z.string(),
-  value: z.number(),
+  id: z.string(),
+  createdAt: z.string(),
   periodicity: z.string(),
+  value: z.number(),
+  unit: z.string(),
+  isActive: z.boolean(),
 });
 export type HabitifyGoal = z.infer<typeof HabitifyGoalSchema>;
 
-/** A habit from the Habitify API. */
+/** Occurrence — discriminated union for scheduling. */
+export const HabitifyOccurrenceSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('daily') }),
+  z.object({ type: z.literal('weekDays'), days: z.array(z.number()) }),
+  z.object({ type: z.literal('intervalDays'), interval: z.number() }),
+]);
+export type HabitifyOccurrence = z.infer<typeof HabitifyOccurrenceSchema>;
+
+/** Time-of-day period embedded in a habit. */
+export const HabitifyTimeOfDaySchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  icon: z.string().nullable().optional(),
+  startTime: z.string().optional(),
+  endTime: z.string().optional(),
+  colorHex: z.string().nullable().optional(),
+});
+export type HabitifyTimeOfDay = z.infer<typeof HabitifyTimeOfDaySchema>;
+
+// ─── Habit ────────────────────────────────────────────
+
+/** A habit from the Habitify API v2. */
 export const HabitifyHabitSchema = z.object({
   id: z.string(),
   name: z.string(),
-  is_archived: z.boolean(),
-  start_date: z.string(),
-  time_of_day: z.array(z.string()),
-  area: HabitifyAreaSchema.nullable(),
-  recurrence: z.string(),
-  goal: HabitifyGoalSchema.nullable(),
-  log_method: z.string(),
-  priority: z.number(),
-  created_date: z.string(),
+  icon: z.string().nullable().optional(),
+  colorHex: z.string().optional(),
+  type: z.string().optional(),
+  description: z.string().nullable().optional(),
+  occurrence: HabitifyOccurrenceSchema,
+  startDate: z.string(),
+  createdAt: z.string(),
+  isArchived: z.boolean(),
+  logMethod: z.string(),
+  goals: z.array(HabitifyGoalSchema),
+  areas: z.array(HabitifyAreaSchema),
+  timeOfDays: z.array(HabitifyTimeOfDaySchema),
 });
 export type HabitifyHabit = z.infer<typeof HabitifyHabitSchema>;
 
-/** A log entry from the Habitify API. */
-export const HabitifyLogSchema = z.object({
-  id: z.string(),
-  habit_id: z.string(),
-  value: z.number(),
-  created_date: z.string(),
-  unit_type: z.string(),
-});
-export type HabitifyLog = z.infer<typeof HabitifyLogSchema>;
+// ─── Statistics / DailyProgress ───────────────────────
 
-/** Generic wrapper for Habitify API responses. */
-export const HabitifyResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
+/** A single day's progress from the statistics endpoint. */
+export const HabitifyDailyProgressSchema = z.object({
+  date: z.string(),
+  totalLog: z.number(),
+  status: z.string(),
+});
+export type HabitifyDailyProgress = z.infer<typeof HabitifyDailyProgressSchema>;
+
+/** Statistics unit object. */
+export const HabitifyStatisticsUnitSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  symbol: z.string(),
+});
+
+/** Response data from GET /habits/{habitId}/statistics. */
+export const HabitifyStatisticsSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  type: z.string().optional(),
+  totalLogs: z.number(),
+  skips: z.number(),
+  fails: z.number(),
+  completions: z.number(),
+  unit: HabitifyStatisticsUnitSchema.nullable().optional(),
+  periodicity: z.string().optional(),
+  avg: z.number().optional(),
+  dailyProgress: z.array(HabitifyDailyProgressSchema),
+});
+export type HabitifyStatistics = z.infer<typeof HabitifyStatisticsSchema>;
+
+// ─── v2 Response wrappers ─────────────────────────────
+
+/** Pagination info returned by v2 list endpoints. */
+export const HabitifyPaginationSchema = z.object({
+  total: z.number(),
+  limit: z.number(),
+  offset: z.number(),
+});
+
+/** Generic wrapper for Habitify API v2 responses. */
+export const HabitifyV2ResponseSchema = <T extends z.ZodTypeAny>(dataSchema: T) =>
   z.object({
-    message: z.string(),
     data: dataSchema,
-    status: z.boolean(),
-    version: z.string(),
+    pagination: HabitifyPaginationSchema.optional(),
   });
-export type HabitifyResponse<T> = {
-  message: string;
+export type HabitifyV2Response<T> = {
   data: T;
-  status: boolean;
-  version: string;
+  pagination?: { total: number; limit: number; offset: number };
 };

--- a/src/lib/habitify/types.ts
+++ b/src/lib/habitify/types.ts
@@ -28,11 +28,14 @@ export const HabitifyGoalSchema = z.object({
 });
 export type HabitifyGoal = z.infer<typeof HabitifyGoalSchema>;
 
-/** Occurrence — discriminated union for scheduling. */
-export const HabitifyOccurrenceSchema = z.discriminatedUnion('type', [
+/** Occurrence — union of known scheduling types, with a passthrough fallback
+ * for unknown/future types so the API adding new occurrence kinds doesn't
+ * break parsing of the whole habit. */
+export const HabitifyOccurrenceSchema = z.union([
   z.object({ type: z.literal('daily') }),
   z.object({ type: z.literal('weekDays'), days: z.array(z.number()) }),
   z.object({ type: z.literal('intervalDays'), interval: z.number() }),
+  z.object({ type: z.string() }).passthrough(),
 ]);
 export type HabitifyOccurrence = z.infer<typeof HabitifyOccurrenceSchema>;
 
@@ -54,7 +57,7 @@ export const HabitifyHabitSchema = z.object({
   id: z.string(),
   name: z.string(),
   icon: z.string().nullable().optional(),
-  colorHex: z.string().optional(),
+  colorHex: z.string().nullable().optional(),
   type: z.string().optional(),
   description: z.string().nullable().optional(),
   occurrence: HabitifyOccurrenceSchema,
@@ -120,3 +123,14 @@ export type HabitifyV2Response<T> = {
   data: T;
   pagination?: { total: number; limit: number; offset: number };
 };
+
+/**
+ * Response envelope for the habits list endpoint, with `data` treated as an
+ * array of unknown elements so each habit can be validated individually
+ * (one malformed habit shouldn't fail the whole page). `data` is also
+ * accepted as `null` (some API responses omit it entirely for empty pages).
+ */
+export const HabitifyHabitsEnvelopeSchema = z.object({
+  data: z.array(z.unknown()).nullable(),
+  pagination: HabitifyPaginationSchema.optional(),
+});


### PR DESCRIPTION
## Summary
- Habitify API v1 → v2 への完全移行 (v1 エンドポイントの使用を廃止)
- 認証方式を `Authorization` ヘッダーから `X-API-Key` ヘッダーに変更
- レスポンス形式を v2 の `{ data, pagination? }` に対応
- ログ取得を `GET /logs/{id}` から `GET /habits/{id}/statistics` の `dailyProgress` に切り替え
- `occurrence` オブジェクトから RRULE への変換、`goals[]` 配列からの tracking_type 推定を実装
- `failed` / `inprogress` ステータスはインポート対象外（未完了扱い）

## 変更ファイル
| ファイル | 変更内容 |
|---------|---------|
| `types.ts` | Zod スキーマを v2 camelCase に全面書き換え |
| `client.ts` | Base URL・認証・ページネーション・getStatistics |
| `transform.ts` | occurrence→RRULE、goals[]対応、transformDailyProgress |
| `import-service.ts` | areas[]対応、statistics ベースのログインポート |
| `*test.ts` (4ファイル) | 全テストを v2 対応に書き換え |

## Test plan
- [x] `pnpm test` — 全630テストパス
- [x] `pnpm lint` — エラー・warning なし
- [x] `pnpm typecheck` — 型エラーなし
- [ ] Habitify API キーを使って実際のインポートを動作確認

Closes #41