### PR TITLE
chore: Dependabot の更新をグループ化して 1 PR にまとめる

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,17 +3,36 @@
 # Please see the documentation for all configuration options:
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 
+# 更新をグループ化して 1 PR にまとめる方針。
+# 個別 PR が並ぶと同じ pnpm-lock.yaml を取り合って毎回コンフリクトするため。
+#
+# npm: major は影響範囲が読めない (Expo SDK のメジャー更新など) ので
+#      グループから外し、従来どおり単独 PR で出す。
+# github-actions: major bump (actions/checkout v4 -> v7 など) が常態で、
+#      lockfile も触らないため major も含めてまとめる。
+
 version: 2
 updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Dependabot の個別 PR が並ぶと同じ `pnpm-lock.yaml` を取り合い、1 つマージするたびに残りが全てコンフリクトするため、更新をグループ化します。

（#59 のマージで #53〜#57 が一斉にコンフリクトしたのがきっかけ）

## 変更内容

| ecosystem | グループ化 | 除外 |
|---|---|---|
| npm | minor / patch を 1 PR に | **major は従来どおり単独 PR** |
| github-actions | 全て 1 PR に | なし |
| docker | 変更なし（対象イメージが 1 つのため） |

## 補足

- npm の major を除外しているのは、Expo SDK のメジャー更新（#55: 52 → 57）のように単独でレビューすべきものを他の更新に埋もれさせないためです。
- github-actions は `actions/checkout v4 → v7` のように major bump が常態で、かつ lockfile を触らずコンフリクトの原因にならないため major も含めてまとめています。

## 注意

このグループ設定が有効になると、次回の Dependabot 実行時に**既存の個別 PR（#54 / #56 / #57）は close され、グループ化された 1 つの PR に置き換わります**。それらを先にマージしたい場合は、このPRのマージを後にしてください。