### PR TITLE
fix(habits): チェックが記録されず、以後つけ外ししても直らない不具合を修正

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -37,7 +37,7 @@ export default function TodayScreen() {
   const [openMenuHabitId, setOpenMenuHabitId] = useState<string | null>(null);
   const weekStart = useWeekStart();
 
-  const {data: habits, isLoading, isFetching, error, refetch} = useHabitsWithLog(selectedDate, weekStart);
+  const {data: habits, isLoading, isFetching, error, refetch, dataUpdatedAt} = useHabitsWithLog(selectedDate, weekStart);
   const toggleLog = useToggleHabitLog();
   const skipLog = useSkipHabitLog();
   const unskipLog = useUnskipHabitLog();
@@ -171,6 +171,7 @@ export default function TodayScreen() {
                         habit={habit}
                         streak={getStreakForDate(habit.id)}
                         onToggle={handleToggle}
+                        syncedAt={dataUpdatedAt}
                         onSkip={() => handleSkip(habit)}
                         onUnskip={() => handleUnskip(habit)}
                         onUncomplete={() => handleToggle(habit)}

--- a/src/components/habits/HabitCard.tsx
+++ b/src/components/habits/HabitCard.tsx
@@ -32,6 +32,17 @@ interface HabitCardProps {
   onUncomplete?: () => void;
   /** メニュー開閉通知コールバック（リンクメニュー or アクションメニュー） */
   onMenuOpenChange?: (open: boolean) => void;
+  /**
+   * 一覧クエリが最後にサーバ応答を受け取った時刻 (React Query の dataUpdatedAt)。
+   *
+   * 楽観表示をサーバ状態へ戻すためのトリガーとして使う。
+   * habit.is_completed だけを依存にすると、ミューテーションが失敗して
+   * サーバ状態が「変わらなかった」場合に同期が走らず、
+   * チェックが付いたままなのに未記録という状態で固着する。
+   * dataUpdatedAt は内容が同一でも再取得のたびに変わるため、
+   * 失敗時にも確実に戻せる。
+   */
+  syncedAt?: number;
 }
 
 /**
@@ -46,6 +57,7 @@ export function HabitCard({
   onUnskip,
   onUncomplete,
   onMenuOpenChange,
+  syncedAt,
 }: HabitCardProps) {
   const {_} = useLingui();
   const isSkipped = habit.is_skipped;
@@ -57,9 +69,11 @@ export function HabitCard({
   const [actionMenuOpen, setActionMenuOpen] = useState(false);
 
   // サーバーからの確定データで同期
+  // syncedAt を依存に含めることで、ミューテーション失敗によりサーバ状態が
+  // 変化しなかった場合でも、再取得のたびに楽観表示を巻き戻せる。
   useEffect(() => {
     setOptimisticCompleted(habit.is_completed);
-  }, [habit.is_completed]);
+  }, [habit.is_completed, habit.log_id, syncedAt]);
 
   const urls = useMemo(() => extractUrls(habit.description), [habit.description]);
 

--- a/src/components/habits/__tests__/HabitCard.test.tsx
+++ b/src/components/habits/__tests__/HabitCard.test.tsx
@@ -441,4 +441,58 @@ describe('HabitCard', () => {
       expect(screen.queryByTestId('habit-actions-menu')).toBeNull();
     });
   });
+
+  describe('楽観表示のサーバ状態への復帰', () => {
+    // 回帰: チェックしても記録されず、以後つけ外ししても直らない不具合。
+    //
+    // ミューテーションが失敗するとサーバ状態は「変化しない」ため、
+    // habit.is_completed のみを依存にした同期では巻き戻しが走らず、
+    // チェックが付いたまま固着していた。
+    // その状態では次のタップが「完了解除」方向になるため、
+    // 完了時のみ再生されるフラッシュアニメーションも走らなくなる。
+    it('再取得後もサーバ状態が未完了なら、楽観表示のチェックを取り消す', () => {
+      const habit = createMockHabitWithLog({is_completed: false, log_id: null});
+      const {rerender} = render(<HabitCard habit={habit} syncedAt={1000} />);
+
+      fireEvent.press(screen.getByTestId('habit-checkbox'));
+      expect(screen.queryByText('✓')).toBeTruthy();
+
+      // ミューテーション失敗 → onSettled の invalidate で再取得が走るが
+      // サーバ状態は未完了のまま（dataUpdatedAt だけが進む）
+      rerender(<HabitCard habit={habit} syncedAt={2000} />);
+
+      expect(screen.queryByText('✓')).toBeNull();
+    });
+
+    it('巻き戻し後のタップは「完了」方向になる（アニメーション再生条件）', () => {
+      const onToggle = jest.fn();
+      const habit = createMockHabitWithLog({is_completed: false, log_id: null});
+      const {rerender} = render(
+        <HabitCard habit={habit} syncedAt={1000} onToggle={onToggle} />,
+      );
+
+      fireEvent.press(screen.getByTestId('habit-checkbox'));
+      rerender(
+        <HabitCard habit={habit} syncedAt={2000} onToggle={onToggle} />,
+      );
+
+      fireEvent.press(screen.getByTestId('habit-checkbox'));
+
+      expect(screen.queryByText('✓')).toBeTruthy();
+      expect(onToggle).toHaveBeenCalledTimes(2);
+    });
+
+    it('再取得でサーバ状態が完了になったらチェックを維持する', () => {
+      const before = createMockHabitWithLog({is_completed: false, log_id: null});
+      const {rerender} = render(<HabitCard habit={before} syncedAt={1000} />);
+
+      fireEvent.press(screen.getByTestId('habit-checkbox'));
+
+      const after = createMockHabitWithLog({is_completed: true, log_id: 'log-1'});
+      rerender(<HabitCard habit={after} syncedAt={2000} />);
+
+      expect(screen.queryByText('✓')).toBeTruthy();
+    });
+  });
+
 });

--- a/src/state/queries/__tests__/habit-logs.test.ts
+++ b/src/state/queries/__tests__/habit-logs.test.ts
@@ -2,14 +2,16 @@ import {describe, expect, it, jest, beforeEach} from '@jest/globals';
 
 // Supabase モック
 const mockFrom = jest.fn();
-const mockGetUser = jest.fn<() => Promise<{data: {user: {id: string} | null}}>>()
-  .mockResolvedValue({data: {user: {id: 'user-1'}}});
+// 書き込みパスはネットワーク往復を避けるため getSession() を使う
+const mockGetSession = jest
+  .fn<() => Promise<{data: {session: {user: {id: string}} | null}}>>()
+  .mockResolvedValue({data: {session: {user: {id: 'user-1'}}}});
 
 jest.mock('@/lib/supabase', () => ({
   supabase: {
     from: (...args: unknown[]) => mockFrom(...args),
     auth: {
-      getUser: () => mockGetUser(),
+      getSession: () => mockGetSession(),
     },
   },
 }));
@@ -43,7 +45,7 @@ const mockedUseMutation = useMutation as jest.MockedFunction<typeof useMutation>
 describe('habit-logs queries', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockGetUser.mockResolvedValue({data: {user: {id: 'user-1'}}});
+    mockGetSession.mockResolvedValue({data: {session: {user: {id: 'user-1'}}}});
   });
 
   describe('useSkipHabitLog', () => {
@@ -124,7 +126,7 @@ describe('habit-logs queries', () => {
     });
 
     it('should throw when user is not authenticated', async () => {
-      mockGetUser.mockResolvedValue({data: {user: null}});
+      mockGetSession.mockResolvedValue({data: {session: null}});
 
       const mutationFn = getSkipMutationFn();
       await expect(

--- a/src/state/queries/habit-logs.ts
+++ b/src/state/queries/habit-logs.ts
@@ -72,7 +72,11 @@ export function useCreateHabitLog() {
   return useMutation({
     mutationFn: async (input: CreateHabitLogInput) => {
       // 現在のユーザーIDを取得
-      const { data: { user } } = await supabase.auth.getUser();
+      // getUser() はネットワーク往復を伴い、GoTrue のロックで直列化される。
+      // 書き込みの前段で詰まると記録自体が失われるため、ローカルの
+      // セッションを読む getSession() を使う。
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user;
       if (!user) {
         throw new Error('認証が必要です');
       }
@@ -91,9 +95,12 @@ export function useCreateHabitLog() {
       if (error) throw error;
       return data as HabitLog;
     },
-    onSuccess: (data) => {
+    onSettled: (data) => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: habitLogKeys.byDate(data.target_date) });
+      // 失敗時は data が undefined になる
+      if (data) {
+        queryClient.invalidateQueries({ queryKey: habitLogKeys.byDate(data.target_date) });
+      }
       queryClient.invalidateQueries({ queryKey: habitKeys.all });
       queryClient.invalidateQueries({ queryKey: streakKeys.all });
     },
@@ -123,9 +130,12 @@ export function useUpdateHabitLog() {
       if (error) throw error;
       return data as HabitLog;
     },
-    onSuccess: (data) => {
+    onSettled: (data) => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
-      queryClient.invalidateQueries({ queryKey: habitLogKeys.byDate(data.target_date) });
+      // 失敗時は data が undefined になる
+      if (data) {
+        queryClient.invalidateQueries({ queryKey: habitLogKeys.byDate(data.target_date) });
+      }
       queryClient.invalidateQueries({ queryKey: habitKeys.all });
       queryClient.invalidateQueries({ queryKey: streakKeys.all });
     },
@@ -153,7 +163,7 @@ export function useDeleteHabitLog() {
 
       return log?.target_date;
     },
-    onSuccess: (targetDate) => {
+    onSettled: (targetDate) => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
       if (targetDate) {
         queryClient.invalidateQueries({ queryKey: habitLogKeys.byDate(targetDate) });
@@ -195,7 +205,8 @@ export function useToggleHabitLog() {
       } else {
         // Create new log (complete)
         // 現在のユーザーIDを取得
-        const { data: { user } } = await supabase.auth.getUser();
+        const { data: { session } } = await supabase.auth.getSession();
+        const user = session?.user;
         if (!user) {
           throw new Error('認証が必要です');
         }
@@ -217,7 +228,7 @@ export function useToggleHabitLog() {
         return data as HabitLog;
       }
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
       queryClient.invalidateQueries({ queryKey: habitKeys.all });
       queryClient.invalidateQueries({ queryKey: streakKeys.all });
@@ -242,7 +253,11 @@ export function useSkipHabitLog() {
       targetDate: string;
       currentLogId?: string | null;
     }) => {
-      const { data: { user } } = await supabase.auth.getUser();
+      // getUser() はネットワーク往復を伴い、GoTrue のロックで直列化される。
+      // 書き込みの前段で詰まると記録自体が失われるため、ローカルの
+      // セッションを読む getSession() を使う。
+      const { data: { session } } = await supabase.auth.getSession();
+      const user = session?.user;
       if (!user) {
         throw new Error('認証が必要です');
       }
@@ -277,7 +292,7 @@ export function useSkipHabitLog() {
         return data as HabitLog;
       }
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
       queryClient.invalidateQueries({ queryKey: habitKeys.all });
       queryClient.invalidateQueries({ queryKey: streakKeys.all });
@@ -297,7 +312,7 @@ export function useUnskipHabitLog() {
 
       if (error) throw error;
     },
-    onSuccess: () => {
+    onSettled: () => {
       queryClient.invalidateQueries({ queryKey: habitLogKeys.lists() });
       queryClient.invalidateQueries({ queryKey: habitKeys.all });
       queryClient.invalidateQueries({ queryKey: streakKeys.all });


### PR DESCRIPTION
## 事象

- 習慣をチェックしても記録されない
- そのとき**チェック時のアニメーションが走らない**
- 一度この状態になると、対象のチェックをつけ外ししても復帰しない
- **別の習慣をチェックすると**アニメーションも走って反映され、**さきほど失敗していた分もまとめて反映される**

## 原因

鍵は `habit_logs` の **`UNIQUE(habit_id, target_date)`** 制約（`CREATE TABLE` 内に定義）です。これと「失敗時にキャッシュを取り直す経路が無いこと」が噛み合って固着していました。

1. 習慣 A をタップ → 楽観的にチェック表示・フラッシュ再生・INSERT 発行
2. その往復が失敗すると `onSuccess` が走らず **`invalidateQueries` されない** → キャッシュは `is_completed: false` / `log_id: null` のまま
3. `HabitCard` の同期は `useEffect(..., [habit.is_completed])`。サーバ状態が **false のまま変化しない**ので effect が発火せず、`optimisticCompleted` が `true` に居座る
4. 次のタップは `willComplete = !true = false` → **完了時のみ再生されるフラッシュが走らない**（＝アニメーションが出ない症状）
5. `log_id` が null のままなので削除分岐に入らず**再び INSERT**。手順 2 で行が実際に入っていれば **UNIQUE 制約違反** → また `onSuccess` が走らない → **つけ外ししても永久に復帰しない**
6. 別の習慣 B をタップ → B は成功 → `invalidateQueries(habitKeys.all)` → 一覧が再取得され、**A の実際の行がようやく読まれて反映される**

手順 6 が「別のタスクを触ると前の失敗分もうまくいく」の正体です。

本質は **「ミューテーションが失敗したときにキャッシュを再取得する経路が存在しない」** ことでした。

## 修正

### 1. `onSuccess` → `onSettled`（habit-logs の全ミューテーション）

成否にかかわらず再取得が走るため、`log_id: null` のまま固着する状態が起きなくなります。これが本丸の修正です。
失敗時は `data` が `undefined` になるので、`data.target_date` を参照していた 2 箇所をガードしました。

### 2. 書き込みパスの `getUser()` → `getSession()`

`getUser()` は**ネットワーク往復**を伴い、GoTrue のロックで直列化されます。INSERT の前段でこれが詰まると記録そのものが失われるため、ローカルのセッションを読む `getSession()` に変更しました。失敗の窓を狭めます。

### 3. `HabitCard` の楽観表示を確実に巻き戻す

同期の依存に `habit.log_id` と `syncedAt`（= React Query の `dataUpdatedAt`）を追加しました。

`dataUpdatedAt` は**内容が同一でも再取得のたびに値が変わる**ため、「失敗してサーバ状態が変化しなかった」ケースでも表示を巻き戻せます。React Query は structural sharing でデータが同一ならオブジェクト参照を維持するので、props の変化だけを頼りにすると検出できません。

## 検証

修正前に再現テストを書き、**想定どおり失敗すること**を確認してから着手しました。

回帰テストを `HabitCard.test.tsx` に 3 件追加しています。空振りでないことも確認済みです:

```
修正を外した状態 → ✕ 2 件失敗
修正を戻した状態 → 39 件すべて通過
```

| チェック | 結果 |
|---|---|
| `pnpm lint` | ✅ |
| `pnpm typecheck` | ✅ |
| `pnpm test:ci` | ✅ 39 suites / **616 tests**（+3） |

既存テストは `getUser` をモックしていたため、実装変更に合わせて `getSession` に更新しました。

### ローカルで実行できなかったもの

`expo export --platform web` と `pnpm check:web` は**ローカルで実行できていません**。作業環境のサンドボックスが `.env` の読み取りを禁止しており、Expo CLI が起動時に弾かれるためです（コードの問題ではありません）。CI の `Build Web` で実行されます。

## 未着手（別途ご判断ください）

- **`src/state/queries/habits.ts:199` と `src/state/queries/user-settings.ts:24` に `getUser()` が残っています。** 同じ性質のリスクですが今回の報告範囲外なので触っていません。同じ 1 行修正で潰せます。
- **エラーが完全にサイレントです。** `mutate()` に `onError` が無く、失敗してもユーザーに何も表示されません。今回の不具合が気付きにくかった一因なので、トースト等の導入を検討する価値があります。